### PR TITLE
infra: docker-compose (Postgres staging + API mock)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copier ce fichier en .env (jamais versionné) et ajuster si besoin.
+# Utilisé par infra/docker/docker-compose.yml et scripts/init_staging_db.sh
+
+POSTGRES_DB=datacore_staging
+POSTGRES_USER=datacore
+POSTGRES_PASSWORD=datacore
+POSTGRES_PORT=5432
+
+API_MOCK_PORT=5050
+API_KEY=datacore-training-2026

--- a/README.md
+++ b/README.md
@@ -8,11 +8,38 @@ entrepôt OMEGA BI (M2), data lake OMEGA LAKE (M3).
 Voir `docs/architecture/` pour l'AS IS/TO BE et le détail des modules `src/datacore/`.
 
 ## Setup local
-\`\`\`bash
+```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cd api-mock && python3 app.py   # API mock TransFlow sur :5050
-\`\`\`
+```
+
+## Setup via Docker Compose
+Alternative conteneurisée : base de staging PostgreSQL + API mock TransFlow.
+
+```bash
+cp .env.example .env
+docker compose -f infra/docker/docker-compose.yml --env-file .env up -d --build
+```
+
+- API mock disponible sur `http://localhost:5050` (voir `.env` pour le port).
+- Base de staging PostgreSQL disponible sur `localhost:5432` (utilisateur/mot
+  de passe/port définis dans `.env`).
+
+Une fois `data/raw/` peuplé avec le pack technique (voir section
+« Données » ci-dessous), initialisez le schéma FluxPro et importez les 7
+CSV dans la base de staging :
+
+```bash
+./scripts/init_staging_db.sh
+```
+
+Pour arrêter et supprimer les conteneurs (les données Postgres sont
+conservées dans un volume nommé) :
+
+```bash
+docker compose -f infra/docker/docker-compose.yml down
+```
 
 ## Données
 `data/raw/` contient le pack pédagogique fourni (non versionné, voir .gitignore).

--- a/api-mock/app.py
+++ b/api-mock/app.py
@@ -243,4 +243,5 @@ def index():
 
 
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=5050, debug=False, threaded=True)
+    host = os.environ.get("API_MOCK_HOST", "127.0.0.1")
+    app.run(host=host, port=5050, debug=False, threaded=True)

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -39,7 +39,7 @@ Voir architecture complète discutée avec Claude Web (conversation du 24/08/202
 - [x] Topographie des données C2 (#3)
 - [x] Architecture AS IS/TO BE C3 (#4)
 - [x] Feuille de route C5 (#6)
-- [ ] Docker-compose (#7)
+- [x] Docker-compose (#7)
 - [ ] CI lint + tests (#8)
 
 ## Règles pour Claude Code

--- a/infra/docker/api-mock.Dockerfile
+++ b/infra/docker/api-mock.Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV API_MOCK_HOST=0.0.0.0
+
+EXPOSE 5050
+
+CMD ["python3", "app.py"]

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: datacore-staging-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-datacore_staging}
+      POSTGRES_USER: ${POSTGRES_USER:-datacore}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-datacore}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - datacore-staging-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-datacore} -d ${POSTGRES_DB:-datacore_staging}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api-mock:
+    build:
+      context: ../../api-mock
+      dockerfile: ../infra/docker/api-mock.Dockerfile
+    container_name: datacore-api-mock
+    restart: unless-stopped
+    ports:
+      - "${API_MOCK_PORT:-5050}:5050"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5050/api/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  datacore-staging-data:

--- a/scripts/init_staging_db.sh
+++ b/scripts/init_staging_db.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Cree le schema FluxPro et importe les 7 CSV dans la base de staging
+# Postgres demarree via infra/docker/docker-compose.yml.
+#
+# Prerequis : `docker compose -f infra/docker/docker-compose.yml up -d`
+# et le pack technique present dans data/raw/ (voir README, non versionne).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ ! -f .env ]; then
+  echo "Fichier .env introuvable : copiez .env.example en .env avant de lancer ce script." >&2
+  exit 1
+fi
+set -a
+source .env
+set +a
+
+RAW_DIR="data/raw"
+SCHEMA_FILE="$RAW_DIR/schema.sql"
+
+if [ ! -f "$SCHEMA_FILE" ]; then
+  echo "Pack technique introuvable ($SCHEMA_FILE)." >&2
+  echo "Copiez le contenu de datacore-dataset/data dans data/raw/ avant de lancer ce script." >&2
+  exit 1
+fi
+
+COMPOSE=(docker compose -f infra/docker/docker-compose.yml)
+PG_USER="${POSTGRES_USER:-datacore}"
+PG_DB="${POSTGRES_DB:-datacore_staging}"
+
+echo "Attente de la disponibilite de la base de staging..."
+until "${COMPOSE[@]}" exec -T db pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; do
+  sleep 1
+done
+
+echo "Creation du schema FluxPro..."
+"${COMPOSE[@]}" exec -T db psql -U "$PG_USER" -d "$PG_DB" < "$SCHEMA_FILE"
+
+# Ordre d'import respectant les cles etrangeres (voir data/raw/schema.sql)
+ORDER=(entrepots clients produits commandes lignes_commande expeditions stocks)
+
+for table in "${ORDER[@]}"; do
+  csv_file="$RAW_DIR/${table}.csv"
+  if [ ! -f "$csv_file" ]; then
+    echo "Fichier manquant : $csv_file" >&2
+    exit 1
+  fi
+  echo "Import de la table $table depuis $csv_file..."
+  "${COMPOSE[@]}" exec -T db psql -U "$PG_USER" -d "$PG_DB" \
+    -c "\\copy $table FROM STDIN DELIMITER ',' CSV HEADER" < "$csv_file"
+done
+
+echo "Import termine."


### PR DESCRIPTION
## Résumé
- `infra/docker/docker-compose.yml` : service `db` (PostgreSQL 16, volume nommé, healthcheck) et service `api-mock` (build depuis `infra/docker/api-mock.Dockerfile`, healthcheck `/api/health`)
- `api-mock/app.py` : écoute désormais configurable via `API_MOCK_HOST` (défaut `127.0.0.1` en local, `0.0.0.0` dans le conteneur) — nécessaire pour que le port mappé du conteneur soit joignable depuis l'hôte
- `.env.example` : variables `POSTGRES_*`, `API_MOCK_PORT`, `API_KEY`
- `scripts/init_staging_db.sh` : crée le schéma FluxPro (`data/raw/schema.sql`) et importe les 7 CSV dans la base de staging, dans l'ordre des clés étrangères
- README mis à jour avec la procédure Docker Compose (au passage : correction des blocs de code cassés par des backticks échappés)
- Case "Docker-compose (#7)" cochée dans `docs/plan_de_developpement.md`

## Closes
Closes #7

## Test plan
- [x] `docker compose up -d --build` : les deux services démarrent et passent `healthy`
- [x] `curl /api/health` répond correctement depuis l'hôte via le port mappé
- [x] `./scripts/init_staging_db.sh` : schéma créé, 7 tables importées (1400 commandes, 4186 lignes de commande, etc.)
- [x] Requête de jointure `commandes ⋈ clients` vérifiée sur les données importées
- [x] `docker compose down -v` nettoie conteneurs, réseau et volume sans laisser de résidu