### PR TITLE
ci: pipeline lint + tests (GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements-dev.txt
+      - run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements-dev.txt -r api-mock/requirements.txt
+      - run: pytest tests/unit tests/integration -v

--- a/api-mock/app.py
+++ b/api-mock/app.py
@@ -33,7 +33,7 @@ import random
 import time
 from datetime import datetime
 
-from flask import Flask, request, jsonify, Response, abort
+from flask import Flask, Response, abort, jsonify, request
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.join(BASE_DIR, "fixtures")
@@ -43,6 +43,15 @@ app = Flask(__name__)
 
 
 def load_json(name):
+    """Charge un fichier JSON de fixtures.
+
+    Args:
+        name: nom du fichier a charger, relatif a `api-mock/fixtures/`
+            (ex. "transporteurs.json").
+
+    Returns:
+        Le contenu desserialise du fichier JSON.
+    """
     with open(os.path.join(FIXTURES_DIR, name), encoding="utf-8") as f:
         return json.load(f)
 
@@ -50,16 +59,30 @@ def load_json(name):
 TRANSPORTEURS = load_json("transporteurs.json")
 TOURNEES = load_json("tournees.json")
 LIVRAISONS = load_json("livraisons.json")
-LIVRAISONS_BY_TRACKING = {l["tracking_number"]: l for l in LIVRAISONS}
+LIVRAISONS_BY_TRACKING = {liv["tracking_number"]: liv for liv in LIVRAISONS}
 
 
 def require_api_key():
+    """Interrompt la requete avec un 401 si l'en-tete X-API-Key est absent ou invalide."""
     key = request.headers.get("X-API-Key")
     if key != API_KEY:
         abort(401, description="Cle API manquante ou invalide. En-tete attendu : X-API-Key")
 
 
 def paginate(items, req):
+    """Pagine une liste selon les parametres `page`/`per_page` de la requete.
+
+    Args:
+        items: liste complete des elements a paginer.
+        req: objet requete exposant `.args.get(...)` (typiquement
+            `flask.request`, ou un objet compatible dans les tests).
+
+    Returns:
+        dict avec les cles `page`, `per_page`, `total`, `total_pages`
+        et `results` (la tranche d'elements de la page demandee).
+        En cas de parametres invalides, retombe sur page=1, per_page=50.
+        `per_page` est plafonne a 200.
+    """
     try:
         page = max(1, int(req.args.get("page", 1)))
         per_page = min(200, max(1, int(req.args.get("per_page", 50))))
@@ -79,27 +102,36 @@ def paginate(items, req):
 
 @app.errorhandler(401)
 def unauthorized(e):
+    """Serialise les erreurs 401 (cle API manquante/invalide) en JSON."""
     return jsonify({"error": "unauthorized", "message": str(e.description)}), 401
 
 
 @app.errorhandler(404)
 def not_found(e):
+    """Serialise les erreurs 404 (ressource introuvable) en JSON."""
     return jsonify({"error": "not_found", "message": str(e.description)}), 404
 
 
 @app.get("/api/health")
 def health():
-    return jsonify({"status": "ok", "service": "TransFlow API (mock pedagogique)", "time": datetime.utcnow().isoformat()})
+    """Verifie la disponibilite du service (sans authentification)."""
+    return jsonify({
+        "status": "ok",
+        "service": "TransFlow API (mock pedagogique)",
+        "time": datetime.utcnow().isoformat(),
+    })
 
 
 @app.get("/api/transporteurs")
 def get_transporteurs():
+    """Liste l'ensemble des transporteurs fictifs."""
     require_api_key()
     return jsonify(TRANSPORTEURS)
 
 
 @app.get("/api/tournees")
 def get_tournees():
+    """Liste les tournees, filtrables par date et transporteur, paginees."""
     require_api_key()
     items = TOURNEES
     date = request.args.get("date")
@@ -113,6 +145,11 @@ def get_tournees():
 
 @app.get("/api/tournees/<int:tournee_id>")
 def get_tournee(tournee_id):
+    """Recupere le detail d'une tournee par son id (404 si absente).
+
+    Args:
+        tournee_id: identifiant de la tournee, extrait de l'URL.
+    """
     require_api_key()
     t = next((x for x in TOURNEES if x["id"] == tournee_id), None)
     if not t:
@@ -122,8 +159,13 @@ def get_tournee(tournee_id):
 
 @app.get("/api/tournees/<int:tournee_id>/livraisons")
 def get_tournee_livraisons(tournee_id):
+    """Liste les livraisons rattachees a une tournee (404 si aucune).
+
+    Args:
+        tournee_id: identifiant de la tournee, extrait de l'URL.
+    """
     require_api_key()
-    items = [l for l in LIVRAISONS if l["tournee_id"] == tournee_id]
+    items = [liv for liv in LIVRAISONS if liv["tournee_id"] == tournee_id]
     if not items:
         abort(404, description=f"Aucune livraison pour la tournee {tournee_id}")
     return jsonify(items)
@@ -131,35 +173,51 @@ def get_tournee_livraisons(tournee_id):
 
 @app.get("/api/livraisons")
 def get_livraisons():
+    """Liste les livraisons, filtrables par statut, paginees."""
     require_api_key()
     items = LIVRAISONS
     statut = request.args.get("statut")
     if statut:
-        items = [l for l in items if l["statut"].lower() == statut.lower()]
+        items = [liv for liv in items if liv["statut"].lower() == statut.lower()]
     return jsonify(paginate(items, request))
 
 
 @app.get("/api/livraisons/<int:livraison_id>")
 def get_livraison(livraison_id):
+    """Recupere le detail d'une livraison par son id (404 si absente).
+
+    Args:
+        livraison_id: identifiant de la livraison, extrait de l'URL.
+    """
     require_api_key()
-    l = next((x for x in LIVRAISONS if x["id"] == livraison_id), None)
-    if not l:
+    liv = next((x for x in LIVRAISONS if x["id"] == livraison_id), None)
+    if not liv:
         abort(404, description=f"Livraison {livraison_id} introuvable")
-    return jsonify(l)
+    return jsonify(liv)
 
 
 # ---------------------------------------------------------------------
 # Flux capteurs temps reel simule (Server-Sent Events) -- generique,
 # a consommer avec l'outil de son choix (aucun broker impose).
 # ---------------------------------------------------------------------
-ZONES_FROIDES = [("OMG-LYO", "Zone froide A"), ("OMG-LIL", "Zone froide B"), ("OMG-MAR", "Zone froide A")]
+ZONES_FROIDES = [
+    ("OMG-LYO", "Zone froide A"),
+    ("OMG-LIL", "Zone froide B"),
+    ("OMG-MAR", "Zone froide A"),
+]
 
 
 @app.get("/api/stream/capteurs")
 def stream_capteurs():
+    """Diffuse un flux continu de mesures capteurs simulees (Server-Sent Events).
+
+    Anticipe le bloc 4 (data lake OMEGA LAKE, C18-C20) : temperature,
+    geolocalisation et identifiant vehicule, un evenement toutes les 2s.
+    """
     require_api_key()
 
     def event_stream():
+        """Generateur infini d'evenements SSE au format `data: <json>\\n\\n`."""
         while True:
             entrepot, zone = random.choice(ZONES_FROIDES)
             payload = {
@@ -193,11 +251,12 @@ td,th{border:1px solid #ccc;padding:6px 10px;text-align:left}
 
 @app.get("/portail-transporteur/colis")
 def portail_index():
+    """Sert la page HTML listant un echantillon de colis (source a scraper)."""
     sample = random.sample(LIVRAISONS, min(40, len(LIVRAISONS)))
     rows = "".join(
-        f'<li><a href="/portail-transporteur/colis/{l["tracking_number"]}">{l["tracking_number"]}</a> '
-        f'&mdash; {l["statut"]}</li>'
-        for l in sample
+        f'<li><a href="/portail-transporteur/colis/{liv["tracking_number"]}">'
+        f'{liv["tracking_number"]}</a> &mdash; {liv["statut"]}</li>'
+        for liv in sample
     )
     html = f"""<!doctype html><html><head><meta charset="utf-8">
     <title>Portail de suivi transporteur</title>{PORTAL_STYLE}</head>
@@ -209,20 +268,25 @@ def portail_index():
 
 @app.get("/portail-transporteur/colis/<tracking_number>")
 def portail_colis(tracking_number):
-    l = LIVRAISONS_BY_TRACKING.get(tracking_number)
-    if not l:
+    """Sert la fiche HTML de suivi d'un colis (source a scraper), 404 si inconnu.
+
+    Args:
+        tracking_number: numero de suivi du colis, extrait de l'URL.
+    """
+    liv = LIVRAISONS_BY_TRACKING.get(tracking_number)
+    if not liv:
         abort(404, description=f"Colis {tracking_number} introuvable")
-    badge_class = "livree" if l["statut"] == "Livree" else "encours"
+    badge_class = "livree" if liv["statut"] == "Livree" else "encours"
     html = f"""<!doctype html><html><head><meta charset="utf-8">
     <title>Suivi colis {tracking_number}</title>{PORTAL_STYLE}</head>
     <body>
     <h1>Suivi du colis {tracking_number}</h1>
     <table>
-      <tr><th>Statut</th><td><span class="badge {badge_class}">{l['statut']}</span></td></tr>
-      <tr><th>Adresse de livraison</th><td>{l['adresse_livraison']}</td></tr>
-      <tr><th>Heure estimee</th><td>{l['heure_estimee']}</td></tr>
-      <tr><th>Heure reelle</th><td>{l['heure_reelle'] or '-'}</td></tr>
-      <tr><th>Tournee</th><td>{l['tournee_id']}</td></tr>
+      <tr><th>Statut</th><td><span class="badge {badge_class}">{liv['statut']}</span></td></tr>
+      <tr><th>Adresse de livraison</th><td>{liv['adresse_livraison']}</td></tr>
+      <tr><th>Heure estimee</th><td>{liv['heure_estimee']}</td></tr>
+      <tr><th>Heure reelle</th><td>{liv['heure_reelle'] or '-'}</td></tr>
+      <tr><th>Tournee</th><td>{liv['tournee_id']}</td></tr>
     </table>
     <p><a href="/portail-transporteur/colis">&larr; retour a la liste</a></p>
     </body></html>"""
@@ -231,13 +295,15 @@ def portail_colis(tracking_number):
 
 @app.get("/")
 def index():
+    """Page d'accueil : recapitule les endpoints disponibles."""
     return jsonify({
         "service": "DATA CORE - API mock pedagogique (TransFlow + portail transporteur)",
         "documentation": "voir README.md a la racine du projet",
         "endpoints": [
             "/api/health", "/api/transporteurs", "/api/tournees", "/api/tournees/<id>",
             "/api/tournees/<id>/livraisons", "/api/livraisons", "/api/livraisons/<id>",
-            "/api/stream/capteurs", "/portail-transporteur/colis", "/portail-transporteur/colis/<tracking_number>",
+            "/api/stream/capteurs", "/portail-transporteur/colis",
+            "/portail-transporteur/colis/<tracking_number>",
         ],
     })
 

--- a/docs/comptes_rendus/M0.md
+++ b/docs/comptes_rendus/M0.md
@@ -1,0 +1,94 @@
+# Compte rendu de milestone — M0 Cadrage & Setup (Bloc 1)
+
+Rédigé à la clôture de l'issue #8 (dernière issue actuellement suivie dans
+le milestone M0), le 25/08/2026.
+
+**⚠️ Voir §4 "Écarts" — ce compte rendu documente un manque avant la
+clôture réelle du milestone : les livrables C4, C6 et C7 attendus par le
+cahier des charges pour le Bloc 1 n'ont pas encore d'issue ni de
+livrable produit.**
+
+---
+
+## 1. Livrables produits
+
+| Livrable | Chemin |
+|---|---|
+| Structure du dépôt, `.gitignore`, README initial | `README.md`, arborescence `src/`, `docs/`, `tests/`, `infra/` |
+| Étude de faisabilité (C1) | `docs/architecture/etude_faisabilite.md` |
+| Topographie des données (C2) | `docs/architecture/topographie_donnees.md` |
+| Étude technique d'architecture AS IS/TO BE (C3) | `docs/architecture/architecture_cible.md` |
+| Feuille de route (C5) | `docs/architecture/feuille_de_route.md` |
+| Conteneurisation (base de staging + API mock) | `infra/docker/docker-compose.yml`, `infra/docker/api-mock.Dockerfile`, `.env.example`, `scripts/init_staging_db.sh` |
+| Pipeline CI (lint + tests) | `.github/workflows/ci.yml`, `pyproject.toml`, `requirements-dev.txt`, `tests/conftest.py`, `tests/unit/test_paginate.py`, `tests/integration/test_api_mock.py` |
+| Règles de projet et suivi Kanban | `docs/plan_de_developpement.md` |
+
+## 2. Compétences couvertes et preuves associées
+
+| Compétence | Statut | Preuve |
+|---|---|---|
+| C1 — Analyser l'expression d'un besoin | Couverte | `etude_faisabilite.md` : grilles d'entretien (Karim BELAÏD, Éléonore RAKOTO, responsables d'entrepôt), contexte, périmètre, étude d'opportunité/faisabilité, analyse RICE, objectifs SMART |
+| C2 — Cartographier les données disponibles | Couverte | `topographie_donnees.md` : glossaire métier, modèles FluxPro/TransFlow/fichiers clients (schémas réels explorés dans `data/raw/` et `api-mock/`), flux, modalités d'accès |
+| C3 — Concevoir un cadre technique d'exploitation | Couverte | `architecture_cible.md` : AS IS/TO BE, matrice des flux, registre RGPD par brique, stratégie RGESN et RGAA |
+| C4 — Réaliser une veille technique et réglementaire | **Non couverte** | Aucun livrable produit — voir §4 |
+| C5 — Planifier la réalisation d'un projet data | Couverte | `feuille_de_route.md` : 4 phases, équipe, budget, Gantt/PERT (Mermaid), outil de suivi (GitHub Projects) |
+| C6 — Superviser la réalisation d'un projet data | **Non couverte** | Aucun livrable produit — voir §4 |
+| C7 — Communiquer tout au long du projet | **Non couverte** | Aucun livrable produit — voir §4 |
+
+## 3. Décisions techniques et justifications
+
+- **PostgreSQL** retenu pour la base de staging : SGBD open source, compatible directement avec `data/raw/schema.sql` fourni, cohérent avec le principe de sobriété RGESN (`architecture_cible.md` §2.3).
+- **MinIO retenu plutôt que Microsoft Fabric** pour le futur data lake OMEGA LAKE : contrainte pédagogique de fonctionnement local sans compte cloud, coût et dépendance fournisseur, reproductibilité pour un évaluateur tiers (`architecture_cible.md` §2.5, décision confirmée avec le superviseur du projet le 24/08/2026).
+- **GitHub Projects** retenu comme outil de suivi Scrum/Kanban plutôt qu'un outil tiers (Trello, Jira) : déjà intégré au dépôt Git, traçabilité directe issue ↔ PR ↔ statut.
+- **Kanban étendu de 3 à 6 statuts** (`Backlog` → `À faire (sprint)` → `En cours` → `En revue (PR)` → `Bloqué` → `Terminé`) le 24/08/2026, pour un suivi plus fin du cycle de vie des issues.
+- **`api-mock/app.py` rendu configurable** via la variable d'environnement `API_MOCK_HOST` (défaut `127.0.0.1` en local, `0.0.0.0` dans le conteneur) : nécessaire pour que le port mappé du conteneur Docker soit joignable depuis l'hôte, sans casser l'usage local documenté au départ.
+- **CI limitée à l'API mock à ce stade** : `ruff` (lint) + `pytest` (tests unitaires sur la fonction pure `paginate()`, tests d'intégration sur les endpoints via le client de test Flask), sans dépendance à des services externes (Postgres, Docker) en CI — choix de rapidité et de simplicité tant que le code de collecte réel (bloc 2) n'existe pas encore.
+
+## 4. Écarts par rapport au cahier des charges
+
+Le cahier des charges (§5.1, Bloc 1) attend un livrable pour chacune des
+compétences C1 à C7. Le suivi GitHub actuel du milestone M0 (issues #1 à
+#8) ne couvre que C1, C2, C3 et C5 :
+
+- **C4 — Veille technique et réglementaire** : « veille hebdomadaire sur
+  les pratiques d'orchestration de flux ETL (DataOps) et sur les
+  obligations RGPD/RGAA applicables au programme ; synthèses communiquées
+  aux parties prenantes » — non entamée, aucune issue créée.
+- **C6 — Superviser la réalisation d'un projet data** : « rituels
+  d'équipe documentés (points hebdomadaires, comité de suivi mensuel
+  CoSu), tableau de suivi budgétaire, encadrement du prestataire externe
+  SupervIT » — non entamée, aucune issue créée.
+- **C7 — Communiquer tout au long de la réalisation** : « plan de
+  communication du programme, supports de la réunion de lancement
+  conformes aux recommandations d'accessibilité, documentation
+  utilisateur des livrables du bloc 1 » — non entamée, aucune issue
+  créée.
+
+Cet écart est significatif : l'épreuve **E2** mobilise explicitement C4 et
+C6 en plus de C1/C2/C3, et l'épreuve **E3** mobilise C5, C6 et C7. Clore
+le milestone M0 en l'état laisserait ces preuves manquantes pour les deux
+épreuves.
+
+**Recommandation** : créer 3 issues supplémentaires dans le milestone M0
+(cadrage encore possible tant que M0 n'est pas formellement clos, cf.
+règle « pas de nouvelle issue hors M0 avant sa clôture ») pour produire
+les livrables C4, C6 et C7 avant de considérer M0 réellement terminé et
+de basculer sur M1.
+
+## 5. Points ouverts / risques pour la suite
+
+- **Gap C4/C6/C7** (§4) à combler avant l'ouverture effective de M1, pour
+  ne pas fragiliser les épreuves E2 et E3.
+- La base de staging PostgreSQL est opérationnelle mais ne contient à ce
+  stade que les données FluxPro (`schema.sql` + 7 CSV) ; l'intégration de
+  TransFlow, des fichiers clients et de l'historique volumineux est
+  prévue au bloc 2 (C8-C10).
+- Le registre RGPD décrit dans `architecture_cible.md` est une structure
+  cible (tableau), pas encore un registre versionné tenu à jour — prévu
+  aux compétences C11 (bloc 2) et C16 (bloc 3).
+- La CI ne couvre pour l'instant que l'API mock ; elle devra être étendue
+  (tests sur les scripts d'ingestion, éventuellement un service Postgres
+  en CI) dès que le code du bloc 2 sera développé.
+- Lors de la session du 24/08/2026, le port 5050 était occupé par un
+  processus Python local resté actif après un test précédent : à vérifier
+  en début de prochaine session avant de relancer `docker compose up`.

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -40,7 +40,12 @@ Voir architecture complète discutée avec Claude Web (conversation du 24/08/202
 - [x] Architecture AS IS/TO BE C3 (#4)
 - [x] Feuille de route C5 (#6)
 - [x] Docker-compose (#7)
-- [ ] CI lint + tests (#8)
+- [x] CI lint + tests (#8)
+
+⚠️ Voir `docs/comptes_rendus/M0.md` §4 : les livrables C4, C6 et C7
+attendus par le cahier des charges pour le Bloc 1 n'ont pas encore
+d'issue GitHub. M0 n'est pas considéré comme clos tant qu'ils ne sont
+pas traités.
 
 ## Règles pour Claude Code
 - Ne jamais committer `data/raw/*` (voir `.gitignore`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+exclude = ["data/raw", ".venv"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests/unit", "tests/integration"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.0
+ruff>=0.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Fixtures pytest partagees pour les tests unitaires et d'integration.
+
+Charge dynamiquement le module `api-mock/app.py` (nom de dossier avec
+tiret, donc non importable via un `import` classique) afin de le tester
+sans dependre du serveur Flask reellement lance.
+"""
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+API_MOCK_DIR = pathlib.Path(__file__).resolve().parents[1] / "api-mock"
+sys.path.insert(0, str(API_MOCK_DIR))
+
+
+def _load_api_mock_app():
+    """Charge `api-mock/app.py` comme module Python autonome.
+
+    Returns:
+        module: le module `app` de l'API mock TransFlow, avec son objet
+            Flask (`app.app`) et ses fonctions utilitaires (`paginate`, ...).
+    """
+    spec = importlib.util.spec_from_file_location("api_mock_app", API_MOCK_DIR / "app.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def api_mock_module():
+    """Module `app.py` de l'API mock, charge une seule fois par session de tests."""
+    return _load_api_mock_app()
+
+
+@pytest.fixture()
+def api_client(api_mock_module):
+    """Client de test Flask pour appeler l'API mock sans serveur reseau reel."""
+    api_mock_module.app.testing = True
+    return api_mock_module.app.test_client()
+
+
+@pytest.fixture()
+def api_key(api_mock_module):
+    """Cle API valide attendue par l'API mock (en-tete X-API-Key)."""
+    return api_mock_module.API_KEY

--- a/tests/integration/test_api_mock.py
+++ b/tests/integration/test_api_mock.py
@@ -1,0 +1,69 @@
+"""Tests d'integration de l'API mock TransFlow (couverture C8/C12).
+
+Exercent le serveur Flask via son client de test (`api_client`, defini
+dans `tests/conftest.py`) : authentification, pagination, filtres et
+portail transporteur a scraper.
+"""
+
+
+def test_health_does_not_require_auth(api_client):
+    """La route de sante est accessible sans cle API."""
+    resp = api_client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+
+
+def test_transporteurs_requires_api_key(api_client):
+    """Toute route /api/* sans en-tete X-API-Key est rejetee (401)."""
+    resp = api_client.get("/api/transporteurs")
+    assert resp.status_code == 401
+
+
+def test_transporteurs_with_valid_key(api_client, api_key):
+    """Avec une cle API valide, la liste des 3 transporteurs fictifs est renvoyee."""
+    resp = api_client.get("/api/transporteurs", headers={"X-API-Key": api_key})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 3
+
+
+def test_tournees_pagination(api_client, api_key):
+    """Le parametre per_page limite bien le nombre de resultats renvoyes."""
+    resp = api_client.get(
+        "/api/tournees?per_page=10&page=1", headers={"X-API-Key": api_key}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["per_page"] == 10
+    assert len(data["results"]) == 10
+
+
+def test_tournee_not_found(api_client, api_key):
+    """Une tournee dont l'id n'existe pas renvoie 404, pas une erreur serveur."""
+    resp = api_client.get("/api/tournees/999999", headers={"X-API-Key": api_key})
+    assert resp.status_code == 404
+
+
+def test_livraisons_filter_by_statut(api_client, api_key):
+    """Le filtre `statut` ne renvoie que les livraisons du statut demande."""
+    resp = api_client.get(
+        "/api/livraisons?statut=Livree&per_page=200", headers={"X-API-Key": api_key}
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["results"]
+    assert all(liv["statut"] == "Livree" for liv in data["results"])
+
+
+def test_portail_transporteur_colis_lists_links(api_client):
+    """La page d'index du portail transporteur (a scraper) repond en HTML."""
+    resp = api_client.get("/portail-transporteur/colis")
+    assert resp.status_code == 200
+    assert b"Portail de suivi transporteur" in resp.data
+
+
+def test_portail_transporteur_colis_detail_not_found(api_client):
+    """Un tracking number inconnu sur le portail transporteur renvoie 404."""
+    resp = api_client.get("/portail-transporteur/colis/UNKNOWN-TRACKING")
+    assert resp.status_code == 404

--- a/tests/unit/test_paginate.py
+++ b/tests/unit/test_paginate.py
@@ -1,0 +1,58 @@
+"""Tests unitaires de la fonction de pagination de l'API mock TransFlow.
+
+Ne necessitent ni serveur Flask ni requete HTTP : `paginate()` est une
+fonction pure, testee directement avec des objets requete factices.
+"""
+
+
+class FakeRequest:
+    """Substitut minimal de `flask.request`, pour tester `paginate()` isolement.
+
+    Args:
+        args: dict simulant `request.args` (parametres de query string).
+    """
+
+    def __init__(self, args):
+        self.args = args
+
+
+def test_paginate_default_page_and_per_page(api_mock_module):
+    """Sans parametre, page=1 et per_page=50 (valeurs par defaut de l'API)."""
+    items = list(range(120))
+    result = api_mock_module.paginate(items, FakeRequest({}))
+    assert result["page"] == 1
+    assert result["per_page"] == 50
+    assert result["total"] == 120
+    assert result["total_pages"] == 3
+    assert result["results"] == items[:50]
+
+
+def test_paginate_caps_per_page_at_200(api_mock_module):
+    """Un per_page demande superieur a 200 est plafonne a 200."""
+    items = list(range(300))
+    result = api_mock_module.paginate(items, FakeRequest({"per_page": "500"}))
+    assert result["per_page"] == 200
+    assert len(result["results"]) == 200
+
+
+def test_paginate_invalid_params_fall_back_to_defaults(api_mock_module):
+    """Des parametres non numeriques ne font pas planter la pagination."""
+    items = list(range(10))
+    result = api_mock_module.paginate(items, FakeRequest({"page": "abc", "per_page": "xyz"}))
+    assert result["page"] == 1
+    assert result["per_page"] == 50
+
+
+def test_paginate_out_of_range_page_returns_empty_results(api_mock_module):
+    """Une page au-dela du nombre d'elements renvoie une liste vide, pas une erreur."""
+    items = list(range(5))
+    result = api_mock_module.paginate(items, FakeRequest({"page": "10"}))
+    assert result["total"] == 5
+    assert result["results"] == []
+
+
+def test_paginate_second_page_offset(api_mock_module):
+    """La page 2 commence bien apres le decalage `per_page` de la page 1."""
+    items = list(range(25))
+    result = api_mock_module.paginate(items, FakeRequest({"page": "2", "per_page": "10"}))
+    assert result["results"] == items[10:20]


### PR DESCRIPTION
## Résumé
- `.github/workflows/ci.yml` : job `lint` (ruff) + job `test` (pytest), déclenchés sur push/PR vers `dev` et `main`
- `pyproject.toml` (config ruff + pytest), `requirements-dev.txt`
- Vrais tests sur le seul code applicatif existant (`api-mock/app.py`), pas un squelette vide :
  - `tests/unit/test_paginate.py` : 5 tests sur la fonction pure `paginate()`
  - `tests/integration/test_api_mock.py` : 8 tests via le client de test Flask (auth, pagination, filtres, 404, portail transporteur à scraper)
- Docstrings ajoutées à toutes les fonctions/classes touchées (scripts, tests, `api-mock/app.py`)
- Corrections lint remontées par ruff sur du code déjà mergé : variables ambiguës `l` → `liv`, lignes > 100 caractères
- `docs/comptes_rendus/M0.md` : compte-rendu de milestone (dernière issue actuellement suivie dans M0)

## ⚠️ Écart identifié — M0 pas réellement clos
En rédigeant le compte-rendu, j'ai vérifié le Bloc 1 du cahier des charges (§5.1) : il attend un livrable par compétence C1 à C7. Le suivi GitHub actuel (#1-#8) ne couvre que **C1, C2, C3, C5**. **C4 (veille), C6 (supervision) et C7 (communication) n'ont aucune issue ni livrable.** Or E2 mobilise C4/C6 et E3 mobilise C6/C7. Détail et recommandation dans `docs/comptes_rendus/M0.md` §4. Je n'ai pas créé les 3 issues manquantes moi-même — à valider avec vous avant de les ouvrir.

## Closes
Closes #8

## Test plan
- [x] `ruff check .` : aucune erreur
- [x] `pytest tests/unit tests/integration -v` : 13/13 tests passent
- [x] Workflow CI vérifié localement (mêmes commandes que `.github/workflows/ci.yml`)