### PR TITLE
feat: extraction automatisée multi-source (C8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .env
 data/raw/*
 !data/raw/README.md
+data/interim/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Voir `docs/architecture/` pour l'AS IS/TO BE et le détail des modules `src/data
 ## Setup local
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements-dev.txt   # installe aussi le package datacore en editable
 cd api-mock && python3 app.py   # API mock TransFlow sur :5050
 ```
 
@@ -43,3 +43,18 @@ docker compose -f infra/docker/docker-compose.yml down
 
 ## Données
 `data/raw/` contient le pack pédagogique fourni (non versionné, voir .gitignore).
+
+## Extraction des données (C8)
+Une fois l'API mock lancée (localement ou via Docker Compose) et la base
+de staging peuplée (`./scripts/init_staging_db.sh`), les cinq sources du
+programme (TransFlow, portail transporteur, FluxPro, fichiers clients,
+historique) peuvent être extraites en une commande :
+
+```bash
+python3 -m datacore.ingestion.run_extraction
+```
+
+Les résultats sont écrits dans `data/interim/` (zone d'atterrissage
+intermédiaire, non versionnée — voir
+`docs/architecture/sequencement_bloc2.md`), en attendant la modélisation
+de la base de travail consolidée (C11).

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -52,13 +52,12 @@ milestone (livrables, compétences couvertes, décisions, points ouverts
 pour M1). Release mergée sur `main` via la PR #25.
 
 ### M1 — Collecte & Stockage (en cours)
-- [ ] Extraction automatisée multi-source C8 (#26)
+- [x] Extraction automatisée multi-source C8 (#26)
 - [ ] Requêtes SQL d'extraction documentées C9 (#27)
 - [ ] Agrégation et nettoyage des fichiers clients C10 (#28)
 - [ ] Base de données de travail — modélisation MERISE C11 (#29)
 - [ ] API Omega Data — exposition sécurisée C12 (#30)
 
-### M1 — Collecte & Stockage (en cours)
 Ordre de traitement retenu pour C8-C12 et justification :
 voir `docs/architecture/sequencement_bloc2.md` — C8 → C10 → C9 → C11 → C12.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "datacore"
+version = "0.1.0"
+description = "DATA CORE — refonte de l'infrastructure data d'Omega Logistics (formation Simplon Data Engineer)."
+requires-python = ">=3.12"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
+-e .
 pytest>=8.0
 ruff>=0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 flask>=3.0
+requests>=2.31
+beautifulsoup4>=4.12
+psycopg2-binary>=2.9
+python-dotenv>=1.0

--- a/src/datacore/__init__.py
+++ b/src/datacore/__init__.py
@@ -1,0 +1,4 @@
+"""Package racine des modules DATA CORE.
+
+Sous-packages : ingestion, processing, storage, api, governance, config.
+"""

--- a/src/datacore/ingestion/__init__.py
+++ b/src/datacore/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Connecteurs d'extraction pour les cinq sources de données du programme DATA CORE (C8)."""

--- a/src/datacore/ingestion/clients_files.py
+++ b/src/datacore/ingestion/clients_files.py
@@ -1,0 +1,77 @@
+"""Lecture brute des fichiers de commandes clients (NordDrive, FreshMarket, MedioTex) (C8).
+
+Couvre la source « fichier de données » attendue par le référentiel (voir
+`docs/architecture/topographie_donnees.md` section 3.3). Chaque client
+utilise un format différent (délimiteur, colonnes) : ce module se
+contente d'une lecture fidèle, sans nettoyage — le dédoublonnage et
+l'homogénéisation des formats sont le rôle de C10.
+"""
+import csv
+from pathlib import Path
+from typing import Any
+
+from datacore.ingestion.config import CLIENTS_FILES_DIR
+
+
+def _read_csv(path: Path, delimiter: str) -> list[dict[str, Any]]:
+    """Lit un fichier CSV en liste de dictionnaires, sans transformation.
+
+    Args:
+        path: chemin du fichier CSV.
+        delimiter: caractère délimiteur de colonnes.
+
+    Returns:
+        La liste des lignes, une par dict colonne -> valeur brute.
+    """
+    with open(path, encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f, delimiter=delimiter))
+
+
+def read_norddrive(path: Path | None = None) -> list[dict[str, Any]]:
+    """Lit le fichier de commandes NordDrive (délimiteur `;`).
+
+    Args:
+        path: chemin du fichier (par défaut celui de `data/raw/`).
+
+    Returns:
+        La liste brute des lignes de commandes NordDrive.
+    """
+    return _read_csv(path or CLIENTS_FILES_DIR / "norddrive_commandes.csv", delimiter=";")
+
+
+def read_freshmarket(path: Path | None = None) -> list[dict[str, Any]]:
+    """Lit le fichier de commandes FreshMarket (délimiteur `,`).
+
+    Args:
+        path: chemin du fichier (par défaut celui de `data/raw/`).
+
+    Returns:
+        La liste brute des lignes de commandes FreshMarket.
+    """
+    return _read_csv(path or CLIENTS_FILES_DIR / "freshmarket_commandes.csv", delimiter=",")
+
+
+def read_mediotex(path: Path | None = None) -> list[dict[str, Any]]:
+    """Lit le fichier de commandes MedioTex (délimiteur `,`).
+
+    Args:
+        path: chemin du fichier (par défaut celui de `data/raw/`).
+
+    Returns:
+        La liste brute des lignes de commandes MedioTex.
+    """
+    return _read_csv(path or CLIENTS_FILES_DIR / "mediotex_commandes.csv", delimiter=",")
+
+
+def read_all_clients() -> dict[str, list[dict[str, Any]]]:
+    """Lit les trois fichiers clients bruts.
+
+    Returns:
+        dict avec les clés "norddrive", "freshmarket", "mediotex", chacune
+        associée à la liste brute des lignes du fichier correspondant.
+    """
+    return {
+        "norddrive": read_norddrive(),
+        "freshmarket": read_freshmarket(),
+        "mediotex": read_mediotex(),
+    }

--- a/src/datacore/ingestion/config.py
+++ b/src/datacore/ingestion/config.py
@@ -1,0 +1,41 @@
+"""Configuration centralisée des connecteurs d'extraction (C8).
+
+Toutes les valeurs sont surchargeables via variables d'environnement.
+Contrairement à `docker-compose` (qui lit `.env` lui-même pour les
+conteneurs) ou à `scripts/init_staging_db.sh` (qui fait `source .env`),
+ces scripts tournent en process Python nu sur l'hôte : `load_dotenv()`
+charge donc explicitement `.env` dans l'environnement du process avant
+lecture, pour que `.env` reste la source de vérité (les valeurs par
+défaut ci-dessous ne servent qu'en dernier recours, ex. avant `cp
+.env.example .env`).
+"""
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+load_dotenv(REPO_ROOT / ".env")
+
+TRANSFLOW_API_URL = os.environ.get("TRANSFLOW_API_URL", "http://127.0.0.1:5050")
+TRANSFLOW_API_KEY = os.environ.get("API_KEY", "datacore-training-2026")
+
+POSTGRES_USER = os.environ.get("POSTGRES_USER", "datacore")
+POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "datacore")
+POSTGRES_DB = os.environ.get("POSTGRES_DB", "datacore_staging")
+POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
+STAGING_DB_DSN = os.environ.get(
+    "STAGING_DB_DSN",
+    f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@localhost:{POSTGRES_PORT}/{POSTGRES_DB}",
+)
+
+RAW_DIR = Path(os.environ.get("DATACORE_RAW_DIR", REPO_ROOT / "data" / "raw"))
+CLIENTS_FILES_DIR = RAW_DIR / "clients_fichiers"
+HISTORIQUE_PATH = RAW_DIR / "historique" / "omega_historique_expeditions.csv"
+
+# Zone d'atterrissage intermédiaire (C8) : les scripts d'extraction y
+# déposent leurs résultats bruts, avant que la base de travail
+# consolidée (C11, modélisation MERISE) n'existe. Non versionnée (voir
+# .gitignore), au même titre que data/raw/.
+INTERIM_DIR = Path(os.environ.get("DATACORE_INTERIM_DIR", REPO_ROOT / "data" / "interim"))

--- a/src/datacore/ingestion/fluxpro.py
+++ b/src/datacore/ingestion/fluxpro.py
@@ -1,0 +1,67 @@
+"""Extraction des données FluxPro depuis la base de staging PostgreSQL (C8).
+
+Couvre la source « base de données » attendue par le référentiel (voir
+`docs/architecture/topographie_donnees.md` section 2). La base de
+staging est déjà peuplée par `scripts/init_staging_db.sh` (issue #7) ;
+ce module se contente de l'interroger.
+
+`fetch_table()` n'utilise que des primitives SQL standard (DB-API 2.0:
+`cursor()`, `.execute()`, `.description`, `.fetchall()`), ce qui la rend
+testable avec n'importe quelle connexion compatible (psycopg2 en
+production, sqlite3 dans les tests unitaires) sans dépendre d'une vraie
+base PostgreSQL.
+"""
+from typing import Any
+
+import psycopg2
+
+from datacore.ingestion.config import STAGING_DB_DSN
+
+FLUXPRO_TABLES = (
+    "entrepots",
+    "clients",
+    "produits",
+    "commandes",
+    "lignes_commande",
+    "expeditions",
+    "stocks",
+)
+
+
+def connect(dsn: str = STAGING_DB_DSN):
+    """Ouvre une connexion à la base de staging PostgreSQL.
+
+    Args:
+        dsn: chaîne de connexion PostgreSQL (surclassable pour les tests).
+
+    Returns:
+        Une connexion psycopg2 ouverte.
+    """
+    return psycopg2.connect(dsn)
+
+
+def fetch_table(conn, table_name: str) -> list[dict[str, Any]]:
+    """Extrait l'intégralité d'une table FluxPro sous forme de dictionnaires.
+
+    Args:
+        conn: connexion DB-API ouverte (psycopg2 en production, sqlite3
+            accepté en test : seules des primitives SQL standard sont
+            utilisées).
+        table_name: nom de la table à extraire ; doit figurer dans
+            `FLUXPRO_TABLES` (liste blanche, évite toute injection SQL
+            via le nom de table, qui ne peut pas être paramétré comme une
+            valeur en SQL standard).
+
+    Returns:
+        La liste des lignes de la table, une par dict colonne -> valeur.
+
+    Raises:
+        ValueError: si `table_name` ne fait pas partie des tables FluxPro
+            connues.
+    """
+    if table_name not in FLUXPRO_TABLES:
+        raise ValueError(f"Table FluxPro inconnue : {table_name!r}")
+    cursor = conn.cursor()
+    cursor.execute(f"SELECT * FROM {table_name}")
+    columns = [desc[0] for desc in cursor.description]
+    return [dict(zip(columns, row, strict=True)) for row in cursor.fetchall()]

--- a/src/datacore/ingestion/historique.py
+++ b/src/datacore/ingestion/historique.py
@@ -1,0 +1,24 @@
+"""Lecture du fichier d'historique volumineux des expéditions (C8).
+
+Couvre la source « système big data » attendue par le référentiel (voir
+`docs/architecture/topographie_donnees.md` section 3.4) : 25 000 lignes,
+période 2022-2026.
+"""
+import csv
+from pathlib import Path
+from typing import Any
+
+from datacore.ingestion.config import HISTORIQUE_PATH
+
+
+def read_historique(path: Path | None = None) -> list[dict[str, Any]]:
+    """Lit l'historique d'expéditions en liste de dictionnaires.
+
+    Args:
+        path: chemin du fichier CSV (par défaut `data/raw/historique/...`).
+
+    Returns:
+        La liste des lignes de l'historique, une par dict colonne -> valeur.
+    """
+    with open(path or HISTORIQUE_PATH, encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f, delimiter=","))

--- a/src/datacore/ingestion/landing.py
+++ b/src/datacore/ingestion/landing.py
@@ -1,0 +1,65 @@
+"""Écriture/lecture des données extraites dans la zone d'atterrissage intermédiaire.
+
+Avant que la base de travail consolidée (C11, modélisation MERISE)
+n'existe, les scripts d'extraction (C8) atterrissent dans des fichiers
+JSON sous `data/interim/` (non versionnés, voir `.gitignore`) : un
+fichier par source, servant d'entrée aux étapes de nettoyage (C10) et
+de modélisation (C11).
+"""
+import datetime
+import decimal
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _json_default(value: Any) -> Any:
+    """Convertit les types non JSON-natifs renvoyés par psycopg2 (C8/FluxPro).
+
+    Args:
+        value: objet que `json.dump` ne sait pas sérialiser nativement
+            (ex. `decimal.Decimal` pour les colonnes NUMERIC/DECIMAL,
+            `datetime.date`/`datetime.datetime` pour les colonnes DATE).
+
+    Returns:
+        Une représentation JSON-compatible (`float` pour un `Decimal`,
+        chaîne ISO 8601 pour une date).
+
+    Raises:
+        TypeError: si le type n'est pas géré, propagée par `json.dump`.
+    """
+    if isinstance(value, decimal.Decimal):
+        return float(value)
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    raise TypeError(f"Objet non sérialisable en JSON : {value!r} ({type(value).__name__})")
+
+
+def write_records(records: list[dict[str, Any]], path: Path) -> Path:
+    """Écrit une liste d'enregistrements en JSON dans la zone d'atterrissage.
+
+    Args:
+        records: liste de dictionnaires à sérialiser.
+        path: chemin du fichier de sortie ; le dossier parent est créé
+            si besoin.
+
+    Returns:
+        Le chemin du fichier écrit (identique à `path`).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(records, f, ensure_ascii=False, indent=2, default=_json_default)
+    return path
+
+
+def read_records(path: Path) -> list[dict[str, Any]]:
+    """Relit une liste d'enregistrements précédemment écrite par `write_records`.
+
+    Args:
+        path: chemin du fichier JSON à lire.
+
+    Returns:
+        La liste de dictionnaires désérialisée.
+    """
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)

--- a/src/datacore/ingestion/portail_scraping.py
+++ b/src/datacore/ingestion/portail_scraping.py
@@ -1,0 +1,60 @@
+"""Scraping du portail transporteur (page HTML de suivi de colis) (C8).
+
+Couvre la source « page web à scraper » attendue par le référentiel (voir
+`docs/architecture/topographie_donnees.md` section 2). Le portail ne
+propose aucune API : les données sont extraites en parsant le HTML des
+pages de liste et de détail.
+"""
+from typing import Any
+
+import requests
+from bs4 import BeautifulSoup
+
+from datacore.ingestion.config import TRANSFLOW_API_URL
+
+
+def scrape_colis_list(base_url: str = TRANSFLOW_API_URL) -> list[str]:
+    """Récupère les numéros de suivi listés sur la page d'index du portail.
+
+    Args:
+        base_url: racine du site à scraper.
+
+    Returns:
+        La liste des numéros de suivi (tracking numbers) trouvés.
+    """
+    resp = requests.get(f"{base_url}/portail-transporteur/colis", timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    links = soup.select("a[href*='/portail-transporteur/colis/']")
+    return [a["href"].rsplit("/", 1)[-1] for a in links]
+
+
+def scrape_colis_detail(tracking_number: str, base_url: str = TRANSFLOW_API_URL) -> dict[str, Any]:
+    """Scrape la fiche de suivi d'un colis.
+
+    Args:
+        tracking_number: numéro de suivi du colis à consulter.
+        base_url: racine du site à scraper.
+
+    Returns:
+        dict avec les clés `tracking_number`, `statut`, `adresse_livraison`,
+        `heure_estimee`, `heure_reelle`, `tournee_id`.
+
+    Raises:
+        requests.HTTPError: si le colis n'existe pas (404).
+    """
+    resp = requests.get(f"{base_url}/portail-transporteur/colis/{tracking_number}", timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    rows = {
+        row.find("th").get_text(strip=True): row.find("td").get_text(strip=True)
+        for row in soup.select("table tr")
+    }
+    return {
+        "tracking_number": tracking_number,
+        "statut": rows.get("Statut"),
+        "adresse_livraison": rows.get("Adresse de livraison"),
+        "heure_estimee": rows.get("Heure estimee"),
+        "heure_reelle": rows.get("Heure reelle"),
+        "tournee_id": rows.get("Tournee"),
+    }

--- a/src/datacore/ingestion/run_extraction.py
+++ b/src/datacore/ingestion/run_extraction.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Orchestre l'extraction des cinq sources du programme DATA CORE et les
+dépose dans la zone d'atterrissage intermédiaire `data/interim/` (C8).
+
+Lancement :
+    python3 -m datacore.ingestion.run_extraction
+
+Prérequis : l'API mock TransFlow doit être lancée (voir README), et la
+base de staging PostgreSQL doit contenir les données FluxPro (voir
+`scripts/init_staging_db.sh`, issue #7) pour l'extraction FluxPro.
+"""
+from datacore.ingestion import clients_files, fluxpro, historique, portail_scraping, transflow
+from datacore.ingestion.config import INTERIM_DIR
+from datacore.ingestion.landing import write_records
+
+
+def extract_transflow() -> None:
+    """Extrait transporteurs, tournées et livraisons TransFlow vers `data/interim/`."""
+    write_records(transflow.fetch_transporteurs(), INTERIM_DIR / "transflow_transporteurs.json")
+    write_records(transflow.fetch_tournees(), INTERIM_DIR / "transflow_tournees.json")
+    write_records(transflow.fetch_livraisons(), INTERIM_DIR / "transflow_livraisons.json")
+
+
+def extract_portail() -> None:
+    """Scrape le portail transporteur (liste + détail de chaque colis) vers `data/interim/`."""
+    tracking_numbers = portail_scraping.scrape_colis_list()
+    details = [portail_scraping.scrape_colis_detail(tn) for tn in tracking_numbers]
+    write_records(details, INTERIM_DIR / "portail_colis.json")
+
+
+def extract_fluxpro() -> None:
+    """Extrait les 7 tables FluxPro depuis la base de staging vers `data/interim/`."""
+    conn = fluxpro.connect()
+    try:
+        for table in fluxpro.FLUXPRO_TABLES:
+            write_records(fluxpro.fetch_table(conn, table), INTERIM_DIR / f"fluxpro_{table}.json")
+    finally:
+        conn.close()
+
+
+def extract_clients() -> None:
+    """Lit les trois fichiers clients bruts vers `data/interim/`."""
+    for name, records in clients_files.read_all_clients().items():
+        write_records(records, INTERIM_DIR / f"clients_{name}.json")
+
+
+def extract_historique() -> None:
+    """Lit l'historique d'expéditions vers `data/interim/`."""
+    write_records(historique.read_historique(), INTERIM_DIR / "historique.json")
+
+
+def main() -> None:
+    """Lance l'ensemble des extractions et affiche un résumé."""
+    steps = {
+        "TransFlow (API)": extract_transflow,
+        "Portail transporteur (scraping)": extract_portail,
+        "FluxPro (base de staging)": extract_fluxpro,
+        "Fichiers clients": extract_clients,
+        "Historique": extract_historique,
+    }
+    for label, step in steps.items():
+        print(f"Extraction : {label}...")
+        step()
+    print(f"Terminé. Fichiers écrits dans {INTERIM_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/datacore/ingestion/transflow.py
+++ b/src/datacore/ingestion/transflow.py
@@ -1,0 +1,112 @@
+"""Extraction des données TransFlow (tournées, livraisons, transporteurs) via l'API REST (C8).
+
+Couvre la source « service web » attendue par le référentiel (voir
+`docs/architecture/topographie_donnees.md` section 2). L'API mock pagine
+ses réponses (`page`, `per_page`) : ce module boucle automatiquement sur
+toutes les pages pour renvoyer la collection complète.
+"""
+from typing import Any
+
+import requests
+
+from datacore.ingestion.config import TRANSFLOW_API_KEY, TRANSFLOW_API_URL
+
+MAX_PER_PAGE = 200
+
+
+def _headers() -> dict[str, str]:
+    """En-têtes HTTP requis par les routes /api/* de TransFlow."""
+    return {"X-API-Key": TRANSFLOW_API_KEY}
+
+
+def _get_json(path: str, params: dict[str, Any] | None, base_url: str) -> Any:
+    """Effectue un GET authentifié sur l'API TransFlow et renvoie le JSON.
+
+    Args:
+        path: chemin de la route, ex. "/api/transporteurs".
+        params: paramètres de requête optionnels (filtres, pagination).
+        base_url: racine de l'API (surclassable pour les tests).
+
+    Returns:
+        Le corps de la réponse désérialisé.
+    """
+    resp = requests.get(f"{base_url}{path}", headers=_headers(), params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_transporteurs(base_url: str = TRANSFLOW_API_URL) -> list[dict[str, Any]]:
+    """Récupère la liste complète des transporteurs.
+
+    Args:
+        base_url: racine de l'API TransFlow.
+
+    Returns:
+        La liste des transporteurs.
+    """
+    return _get_json("/api/transporteurs", None, base_url)
+
+
+def _fetch_paginated(path: str, params: dict[str, Any], base_url: str) -> list[dict[str, Any]]:
+    """Boucle sur toutes les pages d'un endpoint paginé et agrège les résultats.
+
+    Args:
+        path: chemin de la route paginée.
+        params: filtres à appliquer (hors page/per_page, gérés ici).
+        base_url: racine de l'API.
+
+    Returns:
+        La liste complète des éléments, toutes pages confondues.
+    """
+    results: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        payload = _get_json(
+            path, {**params, "page": page, "per_page": MAX_PER_PAGE}, base_url
+        )
+        results.extend(payload["results"])
+        if page >= payload["total_pages"]:
+            break
+        page += 1
+    return results
+
+
+def fetch_tournees(
+    date: str | None = None,
+    transporteur_id: int | None = None,
+    base_url: str = TRANSFLOW_API_URL,
+) -> list[dict[str, Any]]:
+    """Récupère toutes les tournées, avec filtres optionnels.
+
+    Args:
+        date: filtre sur la date de tournée (YYYY-MM-DD), optionnel.
+        transporteur_id: filtre sur le transporteur, optionnel.
+        base_url: racine de l'API.
+
+    Returns:
+        La liste complète des tournées correspondant aux filtres.
+    """
+    params: dict[str, Any] = {}
+    if date:
+        params["date"] = date
+    if transporteur_id is not None:
+        params["transporteur_id"] = transporteur_id
+    return _fetch_paginated("/api/tournees", params, base_url)
+
+
+def fetch_livraisons(
+    statut: str | None = None, base_url: str = TRANSFLOW_API_URL
+) -> list[dict[str, Any]]:
+    """Récupère toutes les livraisons, avec filtre optionnel sur le statut.
+
+    Args:
+        statut: filtre sur le statut de livraison, optionnel.
+        base_url: racine de l'API.
+
+    Returns:
+        La liste complète des livraisons correspondant au filtre.
+    """
+    params: dict[str, Any] = {}
+    if statut:
+        params["statut"] = statut
+    return _fetch_paginated("/api/livraisons", params, base_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,10 @@ sans dependre du serveur Flask reellement lance.
 import importlib.util
 import pathlib
 import sys
+import threading
 
 import pytest
+from werkzeug.serving import make_server
 
 API_MOCK_DIR = pathlib.Path(__file__).resolve().parents[1] / "api-mock"
 sys.path.insert(0, str(API_MOCK_DIR))
@@ -44,3 +46,25 @@ def api_client(api_mock_module):
 def api_key(api_mock_module):
     """Cle API valide attendue par l'API mock (en-tete X-API-Key)."""
     return api_mock_module.API_KEY
+
+
+@pytest.fixture(scope="session")
+def live_api_mock(api_mock_module):
+    """URL de base d'un serveur Flask reel (l'API mock), lance en arriere-plan.
+
+    Contrairement a `api_client` (client de test Flask, pas de vrai
+    reseau), cette fixture permet de tester des clients HTTP (module
+    `requests`, utilises par `datacore.ingestion.transflow` et
+    `datacore.ingestion.portail_scraping`) sans dependre d'un processus
+    `python3 app.py` deja lance manuellement.
+
+    Yields:
+        str: l'URL de base du serveur (ex. "http://127.0.0.1:54321").
+    """
+    server = make_server("127.0.0.1", 0, api_mock_module.app)
+    port = server.server_port
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+    thread.join(timeout=5)

--- a/tests/integration/test_portail_scraping.py
+++ b/tests/integration/test_portail_scraping.py
@@ -1,0 +1,31 @@
+"""Tests d'intégration du scraping du portail transporteur (C8)."""
+import pytest
+import requests
+
+from datacore.ingestion.portail_scraping import scrape_colis_detail, scrape_colis_list
+
+
+def test_scrape_colis_list_returns_tracking_numbers(live_api_mock):
+    """La page d'index expose des numéros de suivi (échantillon de colis)."""
+    tracking_numbers = scrape_colis_list(base_url=live_api_mock)
+
+    assert len(tracking_numbers) > 0
+    assert all(tn.startswith("OMG") for tn in tracking_numbers)
+
+
+def test_scrape_colis_detail_returns_expected_fields(live_api_mock):
+    """La fiche détail d'un colis expose statut, adresse et horaires."""
+    tracking_number = scrape_colis_list(base_url=live_api_mock)[0]
+
+    detail = scrape_colis_detail(tracking_number, base_url=live_api_mock)
+
+    assert detail["tracking_number"] == tracking_number
+    assert detail["statut"] in {"Livree", "En cours"}
+    assert detail["adresse_livraison"]
+    assert detail["tournee_id"]
+
+
+def test_scrape_colis_detail_unknown_tracking_raises(live_api_mock):
+    """Un numéro de suivi inconnu lève une erreur HTTP (404)."""
+    with pytest.raises(requests.HTTPError):
+        scrape_colis_detail("UNKNOWN-TRACKING", base_url=live_api_mock)

--- a/tests/integration/test_transflow.py
+++ b/tests/integration/test_transflow.py
@@ -1,0 +1,48 @@
+"""Tests d'intégration du connecteur TransFlow (C8).
+
+Utilisent la fixture `live_api_mock` (serveur Flask réel en
+arrière-plan) plutôt que le client de test Flask, pour vérifier le
+comportement HTTP réel : authentification, pagination, filtres.
+"""
+from datacore.ingestion.transflow import fetch_livraisons, fetch_tournees, fetch_transporteurs
+
+
+def test_fetch_transporteurs(live_api_mock):
+    """Les 3 transporteurs fictifs sont récupérés."""
+    transporteurs = fetch_transporteurs(base_url=live_api_mock)
+
+    assert len(transporteurs) == 3
+
+
+def test_fetch_tournees_aggregates_all_pages(live_api_mock):
+    """Toutes les tournées sont récupérées malgré la pagination (139 au total)."""
+    tournees = fetch_tournees(base_url=live_api_mock)
+
+    assert len(tournees) == 139
+
+
+def test_fetch_tournees_filters_by_date(live_api_mock):
+    """Le filtre date restreint bien les résultats."""
+    all_tournees = fetch_tournees(base_url=live_api_mock)
+    a_date = all_tournees[0]["date"]
+
+    filtered = fetch_tournees(date=a_date, base_url=live_api_mock)
+
+    assert filtered
+    assert all(t["date"] == a_date for t in filtered)
+    assert len(filtered) <= len(all_tournees)
+
+
+def test_fetch_livraisons_aggregates_all_pages(live_api_mock):
+    """Toutes les livraisons sont récupérées malgré la pagination (1100 au total)."""
+    livraisons = fetch_livraisons(base_url=live_api_mock)
+
+    assert len(livraisons) == 1100
+
+
+def test_fetch_livraisons_filters_by_statut(live_api_mock):
+    """Le filtre statut ne renvoie que les livraisons du statut demandé."""
+    livrees = fetch_livraisons(statut="Livree", base_url=live_api_mock)
+
+    assert livrees
+    assert all(liv["statut"] == "Livree" for liv in livrees)

--- a/tests/unit/test_clients_files.py
+++ b/tests/unit/test_clients_files.py
@@ -1,0 +1,55 @@
+"""Tests unitaires de la lecture brute des fichiers clients (C8).
+
+Utilisent de petits extraits synthétiques reproduisant les particularités
+de format documentées dans `docs/architecture/topographie_donnees.md`
+(délimiteurs, colonnes) plutôt que le jeu de données réel `data/raw/`,
+non versionné et donc absent en CI.
+"""
+from datacore.ingestion.clients_files import read_freshmarket, read_mediotex, read_norddrive
+
+
+def test_read_norddrive_semicolon_delimiter(tmp_path):
+    """Le fichier NordDrive utilise un délimiteur point-virgule."""
+    csv_content = (
+        "ref_commande;date_cde;reference_piece;designation;qte;poids_unitaire_g;entrepot\n"
+        "ND-000001;19-07-2026;SKU-10005;Bougie d'allumage;17;5900;OMG-LIL\n"
+    )
+    path = tmp_path / "norddrive_commandes.csv"
+    path.write_text(csv_content, encoding="utf-8")
+
+    rows = read_norddrive(path)
+
+    assert len(rows) == 1
+    assert rows[0]["ref_commande"] == "ND-000001"
+    assert rows[0]["entrepot"] == "OMG-LIL"
+
+
+def test_read_freshmarket_comma_delimiter(tmp_path):
+    """Le fichier FreshMarket utilise un délimiteur virgule et un booléen métier OUI/NON."""
+    csv_content = (
+        "id_commande_client,date_reception,code_article,libelle_produit,"
+        "quantite_commandee,chaine_froid_requise,site_livraison\n"
+        "FM-000821,06-04-2025,SKU-20011,Yaourt nature 4x125g,28,OUI,OMG-MAR\n"
+    )
+    path = tmp_path / "freshmarket_commandes.csv"
+    path.write_text(csv_content, encoding="utf-8")
+
+    rows = read_freshmarket(path)
+
+    assert len(rows) == 1
+    assert rows[0]["chaine_froid_requise"] == "OUI"
+
+
+def test_read_mediotex_comma_delimiter(tmp_path):
+    """Le fichier MedioTex utilise déjà des noms de colonnes proches du modèle FluxPro."""
+    csv_content = (
+        "numero_cde,date,sku,description,quantite,entrepot_destination\n"
+        "MTX-000159,07/06/2026,SKU-30027,Short de sport,17,OMG-LIL\n"
+    )
+    path = tmp_path / "mediotex_commandes.csv"
+    path.write_text(csv_content, encoding="utf-8")
+
+    rows = read_mediotex(path)
+
+    assert len(rows) == 1
+    assert rows[0]["sku"] == "SKU-30027"

--- a/tests/unit/test_fluxpro.py
+++ b/tests/unit/test_fluxpro.py
@@ -1,0 +1,35 @@
+"""Tests unitaires de l'extraction FluxPro (C8).
+
+`fetch_table()` n'utilise que des primitives SQL standard (DB-API 2.0),
+ce qui permet de la tester avec sqlite3 (stdlib) en remplacement d'une
+vraie base PostgreSQL, sans dépendance externe en CI.
+"""
+import sqlite3
+
+import pytest
+
+from datacore.ingestion.fluxpro import fetch_table
+
+
+@pytest.fixture()
+def sqlite_conn():
+    """Connexion sqlite3 en mémoire avec une table `clients` de test."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE clients (id INTEGER, code TEXT, nom TEXT)")
+    conn.execute("INSERT INTO clients VALUES (1, 'NORDDRIVE', 'NordDrive')")
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def test_fetch_table_returns_rows_as_dicts(sqlite_conn):
+    """Chaque ligne est convertie en dict colonne -> valeur."""
+    rows = fetch_table(sqlite_conn, "clients")
+
+    assert rows == [{"id": 1, "code": "NORDDRIVE", "nom": "NordDrive"}]
+
+
+def test_fetch_table_rejects_unknown_table_name(sqlite_conn):
+    """Un nom de table hors liste blanche est rejeté (protection anti-injection)."""
+    with pytest.raises(ValueError):
+        fetch_table(sqlite_conn, "clients; DROP TABLE clients;--")

--- a/tests/unit/test_historique.py
+++ b/tests/unit/test_historique.py
@@ -1,0 +1,19 @@
+"""Tests unitaires de la lecture de l'historique d'expéditions (C8)."""
+from datacore.ingestion.historique import read_historique
+
+
+def test_read_historique(tmp_path):
+    """Lit un extrait d'historique et préserve toutes les colonnes."""
+    csv_content = (
+        "id,client,entrepot,categorie_produit,date_expedition,poids_kg,"
+        "delai_livraison_jours,cout_transport_eur,statut\n"
+        "1,MedioTex,Marseille,Textile,2024-04-11,29.83,1,52.37,Retardee\n"
+    )
+    path = tmp_path / "historique.csv"
+    path.write_text(csv_content, encoding="utf-8")
+
+    rows = read_historique(path)
+
+    assert len(rows) == 1
+    assert rows[0]["client"] == "MedioTex"
+    assert rows[0]["statut"] == "Retardee"

--- a/tests/unit/test_landing.py
+++ b/tests/unit/test_landing.py
@@ -1,0 +1,43 @@
+"""Tests unitaires de la zone d'atterrissage intermédiaire (écriture/lecture JSON)."""
+import datetime
+import decimal
+
+from datacore.ingestion.landing import read_records, write_records
+
+
+def test_write_then_read_records_roundtrip(tmp_path):
+    """Les enregistrements écrits sont relus à l'identique."""
+    records = [{"id": 1, "nom": "RapidFret"}, {"id": 2, "nom": "TransUnion"}]
+    path = tmp_path / "sub" / "transporteurs.json"
+
+    write_records(records, path)
+
+    assert read_records(path) == records
+
+
+def test_write_records_creates_parent_directories(tmp_path):
+    """Le dossier parent est créé automatiquement s'il n'existe pas."""
+    path = tmp_path / "does" / "not" / "exist" / "out.json"
+
+    write_records([], path)
+
+    assert path.exists()
+
+
+def test_write_records_serializes_decimal_and_date(tmp_path):
+    """Decimal et date/datetime (types renvoyés par psycopg2/FluxPro) sont sérialisables."""
+    records = [
+        {
+            "poids_kg": decimal.Decimal("5.13"),
+            "date_commande": datetime.date(2026, 8, 25),
+            "date_maj": datetime.datetime(2026, 8, 25, 14, 30),
+        }
+    ]
+    path = tmp_path / "fluxpro_produits.json"
+
+    write_records(records, path)
+
+    result = read_records(path)
+    assert result[0]["poids_kg"] == 5.13
+    assert result[0]["date_commande"] == "2026-08-25"
+    assert result[0]["date_maj"] == "2026-08-25T14:30:00"


### PR DESCRIPTION
## Résumé
Cinq connecteurs d'extraction versionnés (`src/datacore/ingestion/`), un par source attendue par le référentiel :
- **`transflow.py`** — API REST TransFlow (transporteurs, tournées, livraisons), pagination automatique
- **`portail_scraping.py`** — scraping des pages HTML de suivi de colis (BeautifulSoup)
- **`fluxpro.py`** — requêtes SQL sur la base de staging, liste blanche de tables (anti-injection), testable via sqlite3 sans Postgres réel
- **`clients_files.py`** — lecture brute des 3 fichiers clients hétérogènes (délimiteurs différents), sans nettoyage (rôle de C10)
- **`historique.py`** — lecture de l'historique volumineux (25 000 lignes)

`run_extraction.py` orchestre les cinq sources en une commande (`python3 -m datacore.ingestion.run_extraction`), écrivant dans `data/interim/` — la zone d'atterrissage intermédiaire (non versionnée) documentée dans `docs/architecture/sequencement_bloc2.md` en attendant la base de travail consolidée (C11).

`config.py` charge explicitement `.env` via `python-dotenv` : ces scripts tournent en process Python nu sur l'hôte, sans la lecture automatique de `.env` que fait `docker-compose` pour les conteneurs.

Packaging : `pyproject.toml` complété en package installable (`pip install -e .`), pour que `datacore.ingestion.*` soit importable partout (tests, scripts, CI).

## Closes
Closes #26

## Test plan
- [x] `ruff check .` : aucune erreur
- [x] `pytest tests/unit tests/integration -v` : 31/31 tests passent (dont tests d'intégration réseau via un serveur Flask réel en arrière-plan, sans Docker requis en CI)
- [x] Test de bout en bout en conditions réelles : `docker compose up` + `init_staging_db.sh` + `run_extraction.py` → les 5 sources extraites avec les volumétries attendues (1400 commandes, 1100 livraisons TransFlow, 25 000 lignes d'historique, 40 colis scrapés, etc.)
- [x] Bug réel découvert et corrigé pendant ce test : `Decimal`/`date` (types renvoyés par psycopg2) non sérialisables en JSON par défaut — `landing.py` gère maintenant ces types, avec test dédié