### PR TITLE
feat: agrégation et nettoyage des fichiers clients (C10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,15 @@ Les résultats sont écrits dans `data/interim/` (zone d'atterrissage
 intermédiaire, non versionnée — voir
 `docs/architecture/sequencement_bloc2.md`), en attendant la modélisation
 de la base de travail consolidée (C11).
+
+## Nettoyage des fichiers clients (C10)
+Une fois l'extraction (C8) effectuée, agrège et nettoie les trois
+fichiers clients (dédoublonnage au grain commande/produit, dates et
+unités homogénéisées) en un jeu de données unique :
+
+```bash
+python3 -m datacore.processing.run_cleaning
+```
+
+Écrit `data/interim/clients_consolidated.json` et affiche un rapport de
+nettoyage (lignes lues, entrées corrompues supprimées, doublons résolus).

--- a/docs/architecture/architecture_cible.md
+++ b/docs/architecture/architecture_cible.md
@@ -43,7 +43,7 @@ et de l'[étude de faisabilité](etude_faisabilite.md#1-contexte) :
 |---|---|---|
 | Flux développés site par site, sans standardisation | Historique, absence de gouvernance data | Incidents non détectés en amont, indicateurs non comparables entre sites |
 | Pas de vue consolidée FluxPro ↔ TransFlow | Deux systèmes cloisonnés, rapprochement manuel | Absence de suivi de bout en bout de l'expédition à la livraison |
-| Fichiers clients hétérogènes ressaisis manuellement | Pas de traitement automatisé (C10) | Doublons, valeurs manquantes, temps perdu (chiffré en [C2 §3.3](topographie_donnees.md#33-fichiers-clients-bruts--formats-hétérogènes) : 55 à 68 % de doublons) |
+| Fichiers clients hétérogènes ressaisis manuellement | Pas de traitement automatisé (C10) | Doublons, valeurs manquantes, temps perdu (chiffré en [C2 §3.3](topographie_donnees.md#33-fichiers-clients-bruts--formats-hétérogènes) : 13 à 17 % de doublons au grain commande/produit) |
 | Absence de registre RGPD | Aucune gouvernance formalisée | Non-conformité, risque juridique jugé « zéro tolérance » par la sponsor |
 | Aucun outil de catalogue ou de documentation partagée | Développements artisanaux non documentés | Dépendance aux personnes, perte de connaissance |
 | Pas d'architecture prête pour la donnée massive (IoT) | Systèmes conçus pour la donnée transactionnelle uniquement | Incapacité à absorber la montée en charge annoncée (capteurs, géoloc, vidéo) |

--- a/docs/architecture/sequencement_bloc2.md
+++ b/docs/architecture/sequencement_bloc2.md
@@ -71,10 +71,16 @@ peut exposer une base qui n'existe pas encore.
 Justification principale : la [topographie des données](topographie_donnees.md)
 (C2) donne une connaissance fiable des *schémas* de chaque source, mais
 pas de leur *contenu réel* une fois extrait et nettoyé — en particulier
-les taux de doublons mesurés (55 à 68 % sur les fichiers clients) montrent
-que la réalité des données dépasse ce qu'un schéma abstrait peut anticiper
-(valeurs de repli, cas de rapprochement entre `tracking_number` FluxPro et
-TransFlow, etc.). Modéliser la base de travail (C11) *après* avoir
+les taux de doublons mesurés (13 à 17 % au grain commande/produit sur les
+fichiers clients, cf. C2 §3.3) montrent que la réalité des données dépasse
+ce qu'un schéma abstrait peut anticiper (valeurs de repli, cas de
+rapprochement entre `tracking_number` FluxPro et TransFlow, etc.). Le
+traitement concret de C10 a d'ailleurs révélé que le premier chiffre
+publié en C2 (mesuré au grain « commande » seul) surestimait fortement le
+phénomène, en confondant commandes multi-produits légitimes et vrais
+doublons — la correction elle-même illustre l'argument : l'analyse
+abstraite ne suffit pas, le contact direct avec la donnée réelle affine
+la compréhension. Modéliser la base de travail (C11) *après* avoir
 concrètement extrait et nettoyé les données limite le risque de devoir
 revoir le schéma MERISE en cours de route. Cet ordre est de plus celui
 suggéré par le cahier des charges, sans qu'aucun argument technique ne

--- a/docs/architecture/topographie_donnees.md
+++ b/docs/architecture/topographie_donnees.md
@@ -139,26 +139,39 @@ l'agrégation (compétence C10) :
 
 | Client | Fichier | Délimiteur | Colonnes | Format de date observé | Particularité |
 |---|---|---|---|---|---|
-| NordDrive | `norddrive_commandes.csv` | `;` | `ref_commande, date_cde, reference_piece, designation, qte, poids_unitaire_g, entrepot` | mixte `DD-MM-YYYY` / `DD/MM/YYYY` | poids en **grammes** (FluxPro utilise des kg) |
-| FreshMarket | `freshmarket_commandes.csv` | `,` | `id_commande_client, date_reception, code_article, libelle_produit, quantite_commandee, chaine_froid_requise, site_livraison` | mixte `DD-MM-YYYY` / `DD/MM/YYYY` | booléen métier `OUI`/`NON` (chaîne du froid) |
-| MedioTex | `mediotex_commandes.csv` | `,` | `numero_cde, date, sku, description, quantite, entrepot_destination` | mixte `DD/MM/YYYY` / `DD-MM-YYYY` | format le plus proche du modèle FluxPro (`sku` déjà nommé ainsi) |
+| NordDrive | `norddrive_commandes.csv` | `;` | `ref_commande, date_cde, reference_piece, designation, qte, poids_unitaire_g, entrepot` | 3 formats mêlés : `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY-MM-DD` | poids en **grammes** (FluxPro utilise des kg) |
+| FreshMarket | `freshmarket_commandes.csv` | `,` | `id_commande_client, date_reception, code_article, libelle_produit, quantite_commandee, chaine_froid_requise, site_livraison` | 3 formats mêlés : `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY-MM-DD` | booléen métier `OUI`/`NON` (chaîne du froid) |
+| MedioTex | `mediotex_commandes.csv` | `,` | `numero_cde, date, sku, description, quantite, entrepot_destination` | 3 formats mêlés : `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY-MM-DD` | format le plus proche du modèle FluxPro (`sku` déjà nommé ainsi) |
 
-**Qualité des données constatée** (mesurée par sondage sur les identifiants
-de commande de chaque fichier) :
+**Qualité des données constatée.** Un identifiant de commande répété dans
+un fichier correspond très majoritairement à une commande **multi-produits
+légitime** (plusieurs lignes, un produit par ligne — comme
+`lignes_commande` dans FluxPro), pas à un doublon : ce n'est donc pas le
+bon grain de mesure. Le grain pertinent est **(commande, produit)** :
 
-| Fichier | Lignes | Doublons d'identifiant | Cellules vides détectées |
-|---|---|---|---|
-| `norddrive_commandes.csv` | 1 479 | 1 013 | 29 |
-| `freshmarket_commandes.csv` | 1 288 | 847 | 27 |
-| `mediotex_commandes.csv` | 1 496 | 1 003 | 0 |
+| Fichier | Lignes | Couples (commande, produit) uniques | Vrais doublons (couple répété) | Cellules vides détectées |
+|---|---|---|---|---|
+| `norddrive_commandes.csv` | 1 479 | 1 263 | 186 | 29 (colonne `qte`) |
+| `freshmarket_commandes.csv` | 1 288 | 1 110 | 161 | 27 (colonne `quantite_commandee`) |
+| `mediotex_commandes.csv` | 1 496 | 1 260 | 218 | 0 |
 
-Ces doublons et cellules vides confirment, chiffres à l'appui, les
-irritants remontés par Karim BELAÏD en entretien (voir
+Ces vrais doublons correspondent le plus souvent à des lignes en conflit
+(même commande, même produit, **quantité différente** et/ou date reformatée)
+plutôt qu'à des répétitions exactes — cohérent avec les irritants remontés
+par Karim BELAÏD en entretien (voir
 [étude de faisabilité §2.1](etude_faisabilite.md#21-entretien-avec-karim-belaïd--responsable-du-pôle-data))
-et justifient la compétence C10 (règles d'agrégation et de nettoyage) :
-dédoublonnage sur l'identifiant de commande client, unification des
-formats de date, conversion des unités (grammes → kg), normalisation des
-booléens métier, et gestion explicite des valeurs manquantes.
+et justifient la compétence C10 (règles d'agrégation et de nettoyage,
+voir [`src/datacore/processing/clients_cleaning.py`](../../src/datacore/processing/clients_cleaning.py)) :
+dédoublonnage au grain (commande, produit) avec résolution des conflits,
+unification des formats de date, conversion des unités (grammes → kg),
+normalisation des booléens métier, et suppression des lignes à quantité
+manquante.
+
+> Correction du 26/08/2026 : la première version de cette section mesurait
+> le taux de doublons au grain (commande) seul, ce qui surestimait
+> fortement le phénomène (55 à 68 %) en confondant commandes
+> multi-produits et doublons réels. Voir le commit associé pour
+> l'historique.
 
 ### 3.4 Historique volumineux (« système big data »)
 
@@ -252,7 +265,7 @@ dans les fichiers clients constituent des données à caractère personnel,
 | Dimension | Constat |
 |---|---|
 | Complétude des sources | Les cinq types de sources attendus par le référentiel (C8) sont couverts, plus les flux IoT anticipant le bloc 4 |
-| Qualité | Bonne sur FluxPro et TransFlow (données structurées et cohérentes) ; dégradée sur les fichiers clients (doublons 55 à 68 %, formats hétérogènes, quelques valeurs manquantes) |
+| Qualité | Bonne sur FluxPro et TransFlow (données structurées et cohérentes) ; dégradée sur les fichiers clients (13 à 17 % de doublons au grain commande/produit, 3 formats de date mêlés, quelques valeurs manquantes) |
 | Volumétrie | Modeste sur FluxPro/TransFlow (dizaines à milliers de lignes) ; plus significative sur l'historique (25 000 lignes) et les flux IoT (jusqu'à ~3 000 lignes par fichier, flux temps réel non borné) |
 | Interopérabilité | Rapprochement nécessaire entre référentiels : `tracking_number` (FluxPro ↔ TransFlow), codes vs libellés d'entrepôt (FluxPro ↔ historique), `sku` hétérogènes selon les fichiers clients |
 | Sécurité d'accès | Authentification minimale (clé API statique) sur TransFlow, aucune sur les autres sources locales — à renforcer dans l'architecture cible (C3) et l'API de mise à disposition (C12) |

--- a/docs/architecture/topographie_donnees.md
+++ b/docs/architecture/topographie_donnees.md
@@ -165,7 +165,14 @@ voir [`src/datacore/processing/clients_cleaning.py`](../../src/datacore/processi
 dédoublonnage au grain (commande, produit) avec résolution des conflits,
 unification des formats de date, conversion des unités (grammes → kg),
 normalisation des booléens métier, et suppression des lignes à quantité
-manquante.
+manquante. Analyse détaillée et reproductible :
+[`notebooks/exploration_fichiers_clients.ipynb`](../../notebooks/exploration_fichiers_clients.ipynb).
+
+Les colonnes `reference_piece` (NordDrive), `code_article` (FreshMarket)
+et `sku` (MedioTex) désignent toutes le même référentiel produit que
+`produits.sku` côté FluxPro (voir glossaire §1) : c'est ce qui permet de
+les unifier sous un champ `sku` commun lors du nettoyage (C10) et, plus
+tard, de les rapprocher de FluxPro dans la base de travail (C11).
 
 > Correction du 26/08/2026 : la première version de cette section mesurait
 > le taux de doublons au grain (commande) seul, ce qui surestimait

--- a/docs/architecture/veille_technique_reglementaire.md
+++ b/docs/architecture/veille_technique_reglementaire.md
@@ -68,7 +68,8 @@ Tour d'horizon des pratiques DataOps de test de qualité de données
 comme Great Expectations ou les tests intégrés à dbt. Ces pratiques
 formalisent un principe déjà identifié empiriquement lors de la
 [topographie des données](topographie_donnees.md#33-fichiers-clients-bruts--formats-hétérogènes)
-(taux de doublons mesurés entre 55 et 68 % sur les fichiers clients).
+(taux de doublons mesurés entre 13 et 17 % au grain commande/produit sur
+les fichiers clients).
 **Décision influencée** : les contrôles qualité (unicité, doublons,
 formats) prévus pour l'agrégation des fichiers clients (bloc 2, C10) et
 pour les pipelines ETL de l'entrepôt (bloc 3, C15) seront formalisés sous

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -33,6 +33,10 @@ Voir architecture complète discutée avec Claude Web (conversation du 24/08/202
 `src/datacore/{ingestion,processing,storage,api,governance,config}`,
 `docs/{architecture,latex,presentation}`, `tests/{unit,integration,playwright}`, `infra/`.
 
+`notebooks/` (ajouté le 26/08/2026) : explorations et analyses de
+données reproductibles, en appui des chiffres cités dans les livrables
+(ex. `notebooks/exploration_fichiers_clients.ipynb` pour C10).
+
 ## État d'avancement
 
 ### M0 — Cadrage & Setup (clos le 25/08/2026)

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -54,7 +54,7 @@ pour M1). Release mergée sur `main` via la PR #25.
 ### M1 — Collecte & Stockage (en cours)
 - [x] Extraction automatisée multi-source C8 (#26)
 - [ ] Requêtes SQL d'extraction documentées C9 (#27)
-- [ ] Agrégation et nettoyage des fichiers clients C10 (#28)
+- [x] Agrégation et nettoyage des fichiers clients C10 (#28)
 - [ ] Base de données de travail — modélisation MERISE C11 (#29)
 - [ ] API Omega Data — exposition sécurisée C12 (#30)
 

--- a/notebooks/exploration_fichiers_clients.ipynb
+++ b/notebooks/exploration_fichiers_clients.ipynb
@@ -1,0 +1,348 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exploration des fichiers clients bruts (C10)\n",
+    "\n",
+    "Documente pas à pas comment les chiffres cités dans\n",
+    "[`docs/architecture/topographie_donnees.md`](../docs/architecture/topographie_donnees.md) §3.3\n",
+    "et implémentés dans\n",
+    "[`src/datacore/processing/clients_cleaning.py`](../src/datacore/processing/clients_cleaning.py)\n",
+    "ont été obtenus, pour que l'analyse reste vérifiable et reproductible\n",
+    "plutôt que de rester une exécution ponctuelle non tracée.\n",
+    "\n",
+    "**Contexte** : trois fichiers de commandes brutes reçues des clients\n",
+    "NordDrive, FreshMarket et MedioTex (`data/raw/clients_fichiers/`),\n",
+    "volontairement hétérogènes et imparfaits (cahier des charges, §3.1).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "from collections import Counter\n",
+    "\n",
+    "FILES = {\n",
+    "    \"norddrive\": (\n",
+    "        \"../data/raw/clients_fichiers/norddrive_commandes.csv\",\n",
+    "        \";\", \"ref_commande\", \"reference_piece\",\n",
+    "    ),\n",
+    "    \"freshmarket\": (\n",
+    "        \"../data/raw/clients_fichiers/freshmarket_commandes.csv\",\n",
+    "        \",\", \"id_commande_client\", \"code_article\",\n",
+    "    ),\n",
+    "    \"mediotex\": (\n",
+    "        \"../data/raw/clients_fichiers/mediotex_commandes.csv\",\n",
+    "        \",\", \"numero_cde\", \"sku\",\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "rows_by_client = {\n",
+    "    name: list(csv.DictReader(open(path, encoding=\"utf-8\"), delimiter=sep))\n",
+    "    for name, (path, sep, _, _) in FILES.items()\n",
+    "}\n",
+    "\n",
+    "for name, rows in rows_by_client.items():\n",
+    "    print(name, \":\", len(rows), \"lignes\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Le piège du grain \"commande\" seul\n",
+    "\n",
+    "Un premier réflexe consiste à mesurer les doublons sur l'identifiant de\n",
+    "commande seul. C'est ce qui a été fait dans la toute première version de\n",
+    "la topographie des données — et c'est trompeur, comme le montre l'exemple\n",
+    "ci-dessous.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = \"norddrive\"\n",
+    "path, sep, key, prod_key = FILES[name]\n",
+    "rows = rows_by_client[name]\n",
+    "\n",
+    "counts = Counter(r[key] for r in rows)\n",
+    "dup_id = next(k for k, v in counts.items() if v > 1)\n",
+    "print(f\"Exemple : {dup_id} apparait {counts[dup_id]} fois\")\n",
+    "for r in [r for r in rows if r[key] == dup_id]:\n",
+    "    print(\" \", r)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On voit immédiatement que ces 4 lignes portent la **même date** et le\n",
+    "**même entrepôt**, mais des `reference_piece` (SKU) et quantités\n",
+    "**différentes** : ce n'est pas un doublon, c'est une commande\n",
+    "multi-produits légitime (une ligne par produit commandé), exactement\n",
+    "comme `lignes_commande` dans FluxPro. Mesurer les \"doublons\" à ce grain\n",
+    "revient à compter le nombre moyen de produits par commande, pas la\n",
+    "qualité des données.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, (path, sep, key, prod_key) in FILES.items():\n",
+    "    rows = rows_by_client[name]\n",
+    "    counts = Counter(r[key] for r in rows)\n",
+    "    n_repeated_ids = sum(1 for v in counts.values() if v > 1)\n",
+    "    print(f\"{name}: {len(rows)} lignes, {len(counts)} commandes uniques, \"\n",
+    "          f\"{n_repeated_ids} commandes avec plusieurs lignes \"\n",
+    "          f\"({n_repeated_ids / len(counts):.0%} des commandes)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "C'est ce calcul (au grain commande seul) qui produisait le chiffre erroné\n",
+    "de \"55 à 68 % de doublons\" dans la première version de la topographie des\n",
+    "données — en réalité le taux de commandes multi-produits, pas un taux de\n",
+    "doublons.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Le bon grain : (commande, produit)\n",
+    "\n",
+    "Le référentiel FluxPro modélise une commande comme `commandes` +\n",
+    "`lignes_commande` (une ligne par produit). Le grain équivalent pour les\n",
+    "fichiers clients bruts est donc **(commande, produit)** : c'est à ce\n",
+    "niveau qu'un doublon a un sens (la même ligne de commande apparaissant\n",
+    "plusieurs fois).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, (path, sep, key, prod_key) in FILES.items():\n",
+    "    rows = rows_by_client[name]\n",
+    "    grain_counts = Counter((r[key], r[prod_key]) for r in rows)\n",
+    "    true_dups = {k: v for k, v in grain_counts.items() if v > 1}\n",
+    "    print(f\"{name}: {len(rows)} lignes, {len(grain_counts)} couples (commande, produit) uniques, \"\n",
+    "          f\"{len(true_dups)} vrais doublons ({len(true_dups) / len(grain_counts):.1%})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ce sont ces pourcentages (**13 à 17 %** selon le client) qui sont retenus\n",
+    "dans la topographie des données et dans le rapport de nettoyage de\n",
+    "`clean_and_aggregate()`.\n",
+    "\n",
+    "### Exemple de vrai doublon, avec conflit de valeurs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = \"norddrive\"\n",
+    "path, sep, key, prod_key = FILES[name]\n",
+    "rows = rows_by_client[name]\n",
+    "grain_counts = Counter((r[key], r[prod_key]) for r in rows)\n",
+    "true_dups = {k: v for k, v in grain_counts.items() if v > 1}\n",
+    "\n",
+    "example_key = next(iter(true_dups))\n",
+    "print(\"Doublon\", example_key, \":\")\n",
+    "for r in rows:\n",
+    "    if (r[key], r[prod_key]) == example_key:\n",
+    "        print(\" \", r)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Les quantités diffèrent (`qte`) et le format de date change d'une ligne à\n",
+    "l'autre, alors qu'il s'agit très probablement de la même date (juste\n",
+    "reformatée). C'est ce type de conflit que `deduplicate()` résout en\n",
+    "conservant la **dernière occurrence rencontrée** — voir la justification\n",
+    "métier détaillée dans le docstring de cette fonction\n",
+    "(`src/datacore/processing/clients_cleaning.py`) : hypothèse d'une mise à\n",
+    "jour de commande par le client, non prouvable à partir des seules\n",
+    "données disponibles, et donc comptabilisée comme conflit résolu plutôt\n",
+    "que silencieusement écrasée.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Valeurs manquantes\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, (path, sep, key, prod_key) in FILES.items():\n",
+    "    rows = rows_by_client[name]\n",
+    "    print(f\"--- {name} ---\")\n",
+    "    for col in rows[0].keys():\n",
+    "        n_empty = sum(1 for r in rows if not r[col] or not r[col].strip())\n",
+    "        if n_empty:\n",
+    "            print(f\"  {col}: {n_empty} valeurs vides\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Seule la colonne quantité est concernée (29 chez NordDrive, 27 chez\n",
+    "FreshMarket, 0 chez MedioTex) — ces lignes sont traitées comme des\n",
+    "entrées corrompues et écartées par `normalize_norddrive`/`normalize_freshmarket`\n",
+    "(impossible de normaliser une ligne sans quantité).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Formats de date rencontrés\n",
+    "\n",
+    "Détection par remplacement des chiffres par `#`, pour faire apparaître le\n",
+    "motif de chaque date sans interpréter sa valeur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "DATE_COLS = {\"norddrive\": \"date_cde\", \"freshmarket\": \"date_reception\", \"mediotex\": \"date\"}\n",
+    "\n",
+    "for name, col in DATE_COLS.items():\n",
+    "    rows = rows_by_client[name]\n",
+    "    patterns = Counter(re.sub(r\"\\d\", \"#\", r[col]) for r in rows)\n",
+    "    print(f\"--- {name} ({col}) ---\")\n",
+    "    for p, c in patterns.most_common():\n",
+    "        print(\" \", p, c)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Trois formats coexistent dans les trois fichiers : `DD/MM/YYYY`,\n",
+    "`DD-MM-YYYY` et `YYYY-MM-DD` — la première version de la topographie des\n",
+    "données n'en documentait que deux. `parse_date()` les gère tous les\n",
+    "trois.\n",
+    "\n",
+    "### Confirmation qu'il s'agit bien de DD/MM/YYYY (et non MM/DD/YYYY)\n",
+    "\n",
+    "On cherche une ligne où le premier nombre dépasse 12 : impossible pour un\n",
+    "mois, ce qui confirme la convention française jour/mois/année.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = rows_by_client[\"norddrive\"]\n",
+    "for r in rows:\n",
+    "    v = r[\"date_cde\"]\n",
+    "    if \"/\" in v:\n",
+    "        d, m, y = v.split(\"/\")\n",
+    "        if int(d) > 12:\n",
+    "            print(\"Confirmé DD/MM/YYYY, exemple :\", v)\n",
+    "            break\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Cohérence des valeurs métier\n",
+    "\n",
+    "Vérification que les codes entrepôt et le booléen métier ne comportent\n",
+    "pas de valeurs aberrantes ou de variantes orthographiques.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fm = rows_by_client[\"freshmarket\"]\n",
+    "print(\"chaine_froid_requise :\", set(r[\"chaine_froid_requise\"] for r in fm))\n",
+    "print(\"site_livraison (FreshMarket) :\", set(r[\"site_livraison\"] for r in fm))\n",
+    "\n",
+    "nd = rows_by_client[\"norddrive\"]\n",
+    "print(\"entrepot (NordDrive) :\", set(r[\"entrepot\"] for r in nd))\n",
+    "\n",
+    "mtx = rows_by_client[\"mediotex\"]\n",
+    "print(\"entrepot_destination (MedioTex) :\", set(r[\"entrepot_destination\"] for r in mtx))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Aucune anomalie : les codes entrepôt correspondent exactement aux trois\n",
+    "sites connus (`OMG-LYO`, `OMG-LIL`, `OMG-MAR`, cohérents avec\n",
+    "`entrepots.code` de FluxPro), et le booléen métier n'a pas de variante\n",
+    "orthographique. Aucun nettoyage supplémentaire n'est nécessaire sur ces\n",
+    "colonnes.\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "Les chiffres retenus dans `docs/architecture/topographie_donnees.md` §3.3\n",
+    "et implémentés dans `src/datacore/processing/clients_cleaning.py`\n",
+    "découlent directement de cette exploration :\n",
+    "\n",
+    "- grain de mesure des doublons : **(commande, produit)**, pas commande seule ;\n",
+    "- taux de vrais doublons : **13 à 17 %** selon le client ;\n",
+    "- valeurs manquantes : uniquement sur la quantité (29 / 27 / 0) ;\n",
+    "- 3 formats de date à gérer : `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY-MM-DD` ;\n",
+    "- codes entrepôt et booléen métier propres, sans nettoyage requis.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/datacore/processing/__init__.py
+++ b/src/datacore/processing/__init__.py
@@ -1,0 +1,1 @@
+"""Règles d'agrégation et de nettoyage des données extraites (C9, C10, C15)."""

--- a/src/datacore/processing/clients_cleaning.py
+++ b/src/datacore/processing/clients_cleaning.py
@@ -5,21 +5,42 @@ Prend en entrée les enregistrements bruts lus par C8
 consolidé, dans un schéma commun aux trois clients (NordDrive,
 FreshMarket, MedioTex) :
 
-- suppression des entrées corrompues (quantité manquante ou non numérique) ;
-- homogénéisation des formats de date (trois formats rencontrés dans les
-  fichiers sources : `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY-MM-DD`) vers ISO 8601 ;
-- homogénéisation des unités (poids NordDrive en grammes -> kg, cohérent
-  avec `produits.poids_kg` de FluxPro) ;
-- suppression des doublons (même commande + même produit), avec
-  résolution des conflits (valeurs différentes pour un même couple)
-  par conservation de la dernière occurrence rencontrée.
+- `normalize_norddrive`/`normalize_freshmarket`/`normalize_mediotex` :
+  normalisent chaque fichier vers le schéma unifié (voir plus bas) — ce
+  sont des fonctions de *normalisation* (mapping de colonnes, formats,
+  unités), pas seulement de nettoyage ; elles écartent au passage les
+  lignes qu'il est impossible de normaliser (quantité manquante ou non
+  numérique), traitées comme des entrées corrompues.
+- `deduplicate` : supprime les vrais doublons (voir note méthodologique
+  ci-dessous) et résout les conflits de valeurs.
+- `clean_and_aggregate` : orchestre les deux étapes précédentes sur les
+  trois fichiers et produit le jeu de données consolidé final.
+
+Schéma unifié produit : `client`, `commande_id`, `date_commande` (ISO
+8601), `sku`, `libelle_produit`, `quantite`, `poids_kg`, `entrepot`,
+`chaine_froid_requise`.
+
+Sur le champ `sku` : les trois fichiers désignent le même concept sous
+des noms de colonnes différents (`reference_piece` chez NordDrive,
+`code_article` chez FreshMarket, `sku` chez MedioTex) : dans les trois
+cas, il s'agit du SKU (Stock Keeping Unit) — la référence unique d'un
+produit tel que catalogué côté FluxPro (`produits.sku`, voir
+[topographie des données §1](../../../docs/architecture/topographie_donnees.md)).
+C'est ce même référentiel produit qui est commandé par les trois
+clients ; le schéma unifié les regroupe donc tous sous un champ `sku`
+unique, condition nécessaire au rapprochement avec FluxPro lors de la
+modélisation de la base de travail (C11).
 
 Note méthodologique (corrige `docs/architecture/topographie_donnees.md`
 §3.3) : un identifiant de commande répété dans un fichier client
 correspond très majoritairement à une commande multi-produits légitime
 (plusieurs lignes, un produit par ligne — comme `lignes_commande` dans
 FluxPro), pas à un doublon. Le vrai doublon se mesure au grain
-(commande, produit) : c'est ce grain qu'utilise `deduplicate()`.
+(commande, produit) : c'est ce grain qu'utilise `deduplicate()`. Cette
+analyse est reproductible dans
+`notebooks/exploration_fichiers_clients.ipynb`, qui documente pas à pas
+comment les chiffres cités ici et dans la topographie des données ont
+été obtenus.
 """
 import datetime
 from typing import Any
@@ -66,8 +87,12 @@ def _parse_quantite(raw: str | None) -> int | None:
         return None
 
 
-def clean_norddrive(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Nettoie et convertit les commandes NordDrive vers le schéma unifié.
+def normalize_norddrive(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalise les commandes NordDrive vers le schéma unifié.
+
+    Convertit le poids (grammes -> kg) et la date (format libre -> ISO).
+    Une ligne dont la quantité est manquante ou non numérique ne peut pas
+    être normalisée : elle est écartée (entrée corrompue).
 
     Args:
         records: lignes brutes telles que lues par
@@ -75,14 +100,13 @@ def clean_norddrive(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     Returns:
         Les lignes valides, converties au schéma unifié (poids en kg).
-        Les lignes à quantité manquante/invalide sont écartées.
     """
-    cleaned = []
+    normalized = []
     for r in records:
         qte = _parse_quantite(r.get("qte"))
         if qte is None:
             continue
-        cleaned.append(
+        normalized.append(
             {
                 "client": "NordDrive",
                 "commande_id": r["ref_commande"],
@@ -95,26 +119,31 @@ def clean_norddrive(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "chaine_froid_requise": None,
             }
         )
-    return cleaned
+    return normalized
 
 
-def clean_freshmarket(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Nettoie et convertit les commandes FreshMarket vers le schéma unifié.
+def normalize_freshmarket(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalise les commandes FreshMarket vers le schéma unifié.
+
+    Convertit le booléen métier OUI/NON en `bool` Python et la date
+    (format libre -> ISO). Une ligne dont la quantité est manquante ou
+    non numérique ne peut pas être normalisée : elle est écartée (entrée
+    corrompue).
 
     Args:
         records: lignes brutes telles que lues par
             `datacore.ingestion.clients_files.read_freshmarket`.
 
     Returns:
-        Les lignes valides, converties au schéma unifié (booléen chaîne du
-        froid). Les lignes à quantité manquante/invalide sont écartées.
+        Les lignes valides, converties au schéma unifié (booléen chaîne
+        du froid).
     """
-    cleaned = []
+    normalized = []
     for r in records:
         qte = _parse_quantite(r.get("quantite_commandee"))
         if qte is None:
             continue
-        cleaned.append(
+        normalized.append(
             {
                 "client": "FreshMarket",
                 "commande_id": r["id_commande_client"],
@@ -127,26 +156,30 @@ def clean_freshmarket(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "chaine_froid_requise": r["chaine_froid_requise"].strip().upper() == "OUI",
             }
         )
-    return cleaned
+    return normalized
 
 
-def clean_mediotex(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Nettoie et convertit les commandes MedioTex vers le schéma unifié.
+def normalize_mediotex(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalise les commandes MedioTex vers le schéma unifié.
+
+    Projette les colonnes (déjà proches du modèle FluxPro) sur le schéma
+    unifié et convertit la date (format libre -> ISO). Une ligne dont la
+    quantité est manquante ou non numérique ne peut pas être normalisée :
+    elle est écartée (entrée corrompue).
 
     Args:
         records: lignes brutes telles que lues par
             `datacore.ingestion.clients_files.read_mediotex`.
 
     Returns:
-        Les lignes valides, converties au schéma unifié. Les lignes à
-        quantité manquante/invalide sont écartées.
+        Les lignes valides, converties au schéma unifié.
     """
-    cleaned = []
+    normalized = []
     for r in records:
         qte = _parse_quantite(r.get("quantite"))
         if qte is None:
             continue
-        cleaned.append(
+        normalized.append(
             {
                 "client": "MedioTex",
                 "commande_id": r["numero_cde"],
@@ -159,7 +192,7 @@ def clean_mediotex(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "chaine_froid_requise": None,
             }
         )
-    return cleaned
+    return normalized
 
 
 def deduplicate(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
@@ -168,12 +201,25 @@ def deduplicate(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], in
     En cas de conflit (valeurs différentes pour un même couple
     commande/produit, ex. quantité différente selon la ligne), la
     dernière occurrence rencontrée dans le fichier source est conservée
-    ("dernière valeur gagne"), et le conflit est comptabilisé pour
-    traçabilité.
+    ("dernière valeur gagne").
+
+    Hypothèse métier retenue et ses limites : les fichiers clients ne
+    portent pas d'horodatage précis (heure), seulement une date ; il est
+    donc impossible de déterminer avec certitude, à partir des seules
+    données disponibles, si un conflit provient d'une erreur de saisie
+    ou d'une mise à jour légitime de la commande transmise par le client
+    (ex. correction de quantité reçue le même jour). On retient
+    conventionnellement l'hypothèse que la dernière ligne rencontrée
+    reflète l'état le plus récent transmis par le client — hypothèse
+    raisonnable mais non prouvable en l'état, à confirmer avec les
+    référents clients en conditions réelles. Chaque conflit est
+    comptabilisé (voir `conflits_resolus` dans le rapport de
+    `clean_and_aggregate`) pour rester traçable et auditable, plutôt que
+    résolu silencieusement.
 
     Args:
-        records: enregistrements déjà convertis au schéma unifié (via
-            `clean_norddrive`/`clean_freshmarket`/`clean_mediotex`).
+        records: enregistrements déjà normalisés au schéma unifié (via
+            `normalize_norddrive`/`normalize_freshmarket`/`normalize_mediotex`).
 
     Returns:
         tuple (liste dédupliquée, nombre de conflits résolus).
@@ -211,19 +257,19 @@ def clean_and_aggregate(
         "freshmarket": len(freshmarket_raw),
         "mediotex": len(mediotex_raw),
     }
-    cleaned = (
-        clean_norddrive(norddrive_raw)
-        + clean_freshmarket(freshmarket_raw)
-        + clean_mediotex(mediotex_raw)
+    normalized = (
+        normalize_norddrive(norddrive_raw)
+        + normalize_freshmarket(freshmarket_raw)
+        + normalize_mediotex(mediotex_raw)
     )
-    corrompues = sum(raw_counts.values()) - len(cleaned)
-    deduped, conflicts = deduplicate(cleaned)
+    corrompues = sum(raw_counts.values()) - len(normalized)
+    deduped, conflicts = deduplicate(normalized)
     return {
         "records": deduped,
         "rapport": {
             "lignes_lues": raw_counts,
             "lignes_corrompues_supprimees": corrompues,
-            "doublons_supprimes": len(cleaned) - len(deduped),
+            "doublons_supprimes": len(normalized) - len(deduped),
             "conflits_resolus": conflicts,
         },
     }

--- a/src/datacore/processing/clients_cleaning.py
+++ b/src/datacore/processing/clients_cleaning.py
@@ -1,0 +1,229 @@
+"""Nettoyage et agrégation des fichiers clients bruts en un jeu de données unique (C10).
+
+Prend en entrée les enregistrements bruts lus par C8
+(`datacore.ingestion.clients_files`) et produit un jeu de données
+consolidé, dans un schéma commun aux trois clients (NordDrive,
+FreshMarket, MedioTex) :
+
+- suppression des entrées corrompues (quantité manquante ou non numérique) ;
+- homogénéisation des formats de date (trois formats rencontrés dans les
+  fichiers sources : `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY-MM-DD`) vers ISO 8601 ;
+- homogénéisation des unités (poids NordDrive en grammes -> kg, cohérent
+  avec `produits.poids_kg` de FluxPro) ;
+- suppression des doublons (même commande + même produit), avec
+  résolution des conflits (valeurs différentes pour un même couple)
+  par conservation de la dernière occurrence rencontrée.
+
+Note méthodologique (corrige `docs/architecture/topographie_donnees.md`
+§3.3) : un identifiant de commande répété dans un fichier client
+correspond très majoritairement à une commande multi-produits légitime
+(plusieurs lignes, un produit par ligne — comme `lignes_commande` dans
+FluxPro), pas à un doublon. Le vrai doublon se mesure au grain
+(commande, produit) : c'est ce grain qu'utilise `deduplicate()`.
+"""
+import datetime
+from typing import Any
+
+DATE_FORMATS = ("%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%d")
+
+
+def parse_date(raw: str) -> str:
+    """Normalise une date exprimée dans l'un des trois formats rencontrés en ISO 8601.
+
+    Args:
+        raw: date brute, ex. "16/05/2026", "15-06-2026" ou "2025-03-07".
+
+    Returns:
+        La date au format ISO "YYYY-MM-DD".
+
+    Raises:
+        ValueError: si `raw` ne correspond à aucun des formats connus.
+    """
+    for fmt in DATE_FORMATS:
+        try:
+            return datetime.datetime.strptime(raw.strip(), fmt).date().isoformat()
+        except ValueError:
+            continue
+    raise ValueError(f"Format de date non reconnu : {raw!r}")
+
+
+def _parse_quantite(raw: str | None) -> int | None:
+    """Convertit une quantité brute en entier, ou None si absente/invalide.
+
+    Args:
+        raw: valeur brute de la colonne quantité.
+
+    Returns:
+        L'entier correspondant, ou None si la valeur est vide ou non
+        numérique (cas traité comme une entrée corrompue par l'appelant).
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def clean_norddrive(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Nettoie et convertit les commandes NordDrive vers le schéma unifié.
+
+    Args:
+        records: lignes brutes telles que lues par
+            `datacore.ingestion.clients_files.read_norddrive`.
+
+    Returns:
+        Les lignes valides, converties au schéma unifié (poids en kg).
+        Les lignes à quantité manquante/invalide sont écartées.
+    """
+    cleaned = []
+    for r in records:
+        qte = _parse_quantite(r.get("qte"))
+        if qte is None:
+            continue
+        cleaned.append(
+            {
+                "client": "NordDrive",
+                "commande_id": r["ref_commande"],
+                "date_commande": parse_date(r["date_cde"]),
+                "sku": r["reference_piece"],
+                "libelle_produit": r["designation"],
+                "quantite": qte,
+                "poids_kg": round(int(r["poids_unitaire_g"]) / 1000, 3),
+                "entrepot": r["entrepot"],
+                "chaine_froid_requise": None,
+            }
+        )
+    return cleaned
+
+
+def clean_freshmarket(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Nettoie et convertit les commandes FreshMarket vers le schéma unifié.
+
+    Args:
+        records: lignes brutes telles que lues par
+            `datacore.ingestion.clients_files.read_freshmarket`.
+
+    Returns:
+        Les lignes valides, converties au schéma unifié (booléen chaîne du
+        froid). Les lignes à quantité manquante/invalide sont écartées.
+    """
+    cleaned = []
+    for r in records:
+        qte = _parse_quantite(r.get("quantite_commandee"))
+        if qte is None:
+            continue
+        cleaned.append(
+            {
+                "client": "FreshMarket",
+                "commande_id": r["id_commande_client"],
+                "date_commande": parse_date(r["date_reception"]),
+                "sku": r["code_article"],
+                "libelle_produit": r["libelle_produit"],
+                "quantite": qte,
+                "poids_kg": None,
+                "entrepot": r["site_livraison"],
+                "chaine_froid_requise": r["chaine_froid_requise"].strip().upper() == "OUI",
+            }
+        )
+    return cleaned
+
+
+def clean_mediotex(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Nettoie et convertit les commandes MedioTex vers le schéma unifié.
+
+    Args:
+        records: lignes brutes telles que lues par
+            `datacore.ingestion.clients_files.read_mediotex`.
+
+    Returns:
+        Les lignes valides, converties au schéma unifié. Les lignes à
+        quantité manquante/invalide sont écartées.
+    """
+    cleaned = []
+    for r in records:
+        qte = _parse_quantite(r.get("quantite"))
+        if qte is None:
+            continue
+        cleaned.append(
+            {
+                "client": "MedioTex",
+                "commande_id": r["numero_cde"],
+                "date_commande": parse_date(r["date"]),
+                "sku": r["sku"],
+                "libelle_produit": r["description"],
+                "quantite": qte,
+                "poids_kg": None,
+                "entrepot": r["entrepot_destination"],
+                "chaine_froid_requise": None,
+            }
+        )
+    return cleaned
+
+
+def deduplicate(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    """Supprime les doublons au grain (client, commande, produit).
+
+    En cas de conflit (valeurs différentes pour un même couple
+    commande/produit, ex. quantité différente selon la ligne), la
+    dernière occurrence rencontrée dans le fichier source est conservée
+    ("dernière valeur gagne"), et le conflit est comptabilisé pour
+    traçabilité.
+
+    Args:
+        records: enregistrements déjà convertis au schéma unifié (via
+            `clean_norddrive`/`clean_freshmarket`/`clean_mediotex`).
+
+    Returns:
+        tuple (liste dédupliquée, nombre de conflits résolus).
+    """
+    by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    conflicts = 0
+    for r in records:
+        key = (r["client"], r["commande_id"], r["sku"])
+        if key in by_key and by_key[key] != r:
+            conflicts += 1
+        by_key[key] = r
+    return list(by_key.values()), conflicts
+
+
+def clean_and_aggregate(
+    norddrive_raw: list[dict[str, Any]],
+    freshmarket_raw: list[dict[str, Any]],
+    mediotex_raw: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Nettoie et fusionne les trois fichiers clients en un jeu de données unique.
+
+    Args:
+        norddrive_raw: lignes brutes NordDrive.
+        freshmarket_raw: lignes brutes FreshMarket.
+        mediotex_raw: lignes brutes MedioTex.
+
+    Returns:
+        dict avec les clés "records" (jeu de données consolidé, schéma
+        unifié) et "rapport" (statistiques de nettoyage : lignes lues par
+        source, entrées corrompues supprimées, doublons supprimés,
+        conflits résolus).
+    """
+    raw_counts = {
+        "norddrive": len(norddrive_raw),
+        "freshmarket": len(freshmarket_raw),
+        "mediotex": len(mediotex_raw),
+    }
+    cleaned = (
+        clean_norddrive(norddrive_raw)
+        + clean_freshmarket(freshmarket_raw)
+        + clean_mediotex(mediotex_raw)
+    )
+    corrompues = sum(raw_counts.values()) - len(cleaned)
+    deduped, conflicts = deduplicate(cleaned)
+    return {
+        "records": deduped,
+        "rapport": {
+            "lignes_lues": raw_counts,
+            "lignes_corrompues_supprimees": corrompues,
+            "doublons_supprimes": len(cleaned) - len(deduped),
+            "conflits_resolus": conflicts,
+        },
+    }

--- a/src/datacore/processing/run_cleaning.py
+++ b/src/datacore/processing/run_cleaning.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Nettoie et agrège les fichiers clients extraits par C8 (C10).
+
+Lit les trois fichiers clients bruts depuis la zone d'atterrissage
+intermédiaire déposée par `datacore.ingestion.run_extraction`
+(`data/interim/clients_*.json`), produit le jeu de données consolidé
+unique, et l'écrit dans `data/interim/clients_consolidated.json`.
+
+Lancement :
+    python3 -m datacore.processing.run_cleaning
+
+Prérequis : avoir lancé au préalable
+`python3 -m datacore.ingestion.run_extraction` (C8).
+"""
+import json
+
+from datacore.ingestion.config import INTERIM_DIR
+from datacore.ingestion.landing import read_records, write_records
+from datacore.processing.clients_cleaning import clean_and_aggregate
+
+
+def main() -> None:
+    """Nettoie les trois fichiers clients et écrit le jeu de données consolidé."""
+    norddrive_raw = read_records(INTERIM_DIR / "clients_norddrive.json")
+    freshmarket_raw = read_records(INTERIM_DIR / "clients_freshmarket.json")
+    mediotex_raw = read_records(INTERIM_DIR / "clients_mediotex.json")
+
+    result = clean_and_aggregate(norddrive_raw, freshmarket_raw, mediotex_raw)
+
+    write_records(result["records"], INTERIM_DIR / "clients_consolidated.json")
+    print(json.dumps(result["rapport"], indent=2, ensure_ascii=False))
+    print(f"{len(result['records'])} lignes consolidées écrites dans {INTERIM_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_clients_cleaning.py
+++ b/tests/unit/test_clients_cleaning.py
@@ -1,0 +1,205 @@
+"""Tests unitaires du nettoyage et de l'agrégation des fichiers clients (C10).
+
+Les scénarios reproduisent les cas réels observés dans le jeu de données
+(voir `docs/architecture/topographie_donnees.md` §3.3) : commandes
+multi-produits légitimes, vrais doublons (même commande + même produit)
+avec conflit de valeurs, doublons de pure forme (date différemment
+formatée), et lignes corrompues (quantité manquante).
+"""
+import pytest
+
+from datacore.processing.clients_cleaning import (
+    clean_and_aggregate,
+    clean_freshmarket,
+    clean_mediotex,
+    clean_norddrive,
+    deduplicate,
+    parse_date,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("16/05/2026", "2026-05-16"),
+        ("15-06-2026", "2026-06-15"),
+        ("2025-03-07", "2025-03-07"),
+    ],
+)
+def test_parse_date_handles_all_three_formats(raw, expected):
+    """Les trois formats de date rencontrés dans les fichiers clients sont reconnus."""
+    assert parse_date(raw) == expected
+
+
+def test_parse_date_rejects_unknown_format():
+    """Un format non reconnu lève une erreur explicite plutôt qu'un résultat silencieux."""
+    with pytest.raises(ValueError):
+        parse_date("07.03.2025")
+
+
+def test_clean_norddrive_converts_grams_to_kg():
+    """Le poids NordDrive (grammes) est converti en kg, cohérent avec FluxPro."""
+    raw = [
+        {
+            "ref_commande": "ND-000001",
+            "date_cde": "19-07-2026",
+            "reference_piece": "SKU-10005",
+            "designation": "Bougie d'allumage",
+            "qte": "17",
+            "poids_unitaire_g": "5900",
+            "entrepot": "OMG-LIL",
+        }
+    ]
+
+    cleaned = clean_norddrive(raw)
+
+    assert cleaned[0]["poids_kg"] == 5.9
+    assert cleaned[0]["client"] == "NordDrive"
+    assert cleaned[0]["quantite"] == 17
+
+
+def test_clean_norddrive_drops_rows_with_missing_quantite():
+    """Une ligne sans quantité est une entrée corrompue, écartée."""
+    raw = [
+        {
+            "ref_commande": "ND-000002",
+            "date_cde": "19-07-2026",
+            "reference_piece": "SKU-10005",
+            "designation": "Bougie d'allumage",
+            "qte": "",
+            "poids_unitaire_g": "5900",
+            "entrepot": "OMG-LIL",
+        }
+    ]
+
+    assert clean_norddrive(raw) == []
+
+
+def test_clean_freshmarket_converts_oui_non_to_boolean():
+    """Le booléen métier OUI/NON est converti en bool Python."""
+    raw = [
+        {
+            "id_commande_client": "FM-000821",
+            "date_reception": "06-04-2025",
+            "code_article": "SKU-20011",
+            "libelle_produit": "Yaourt nature 4x125g",
+            "quantite_commandee": "28",
+            "chaine_froid_requise": "OUI",
+            "site_livraison": "OMG-MAR",
+        }
+    ]
+
+    cleaned = clean_freshmarket(raw)
+
+    assert cleaned[0]["chaine_froid_requise"] is True
+    assert cleaned[0]["poids_kg"] is None
+
+
+def test_clean_mediotex_maps_columns_to_unified_schema():
+    """Les colonnes MedioTex sont correctement projetées sur le schéma unifié."""
+    raw = [
+        {
+            "numero_cde": "MTX-000159",
+            "date": "07/06/2026",
+            "sku": "SKU-30027",
+            "description": "Short de sport",
+            "quantite": "17",
+            "entrepot_destination": "OMG-LIL",
+        }
+    ]
+
+    cleaned = clean_mediotex(raw)
+
+    assert cleaned[0]["client"] == "MedioTex"
+    assert cleaned[0]["sku"] == "SKU-30027"
+    assert cleaned[0]["date_commande"] == "2026-06-07"
+
+
+def test_deduplicate_keeps_legitimate_multi_product_orders():
+    """Une commande multi-produits (plusieurs SKU différents) n'est pas un doublon."""
+    records = [
+        {"client": "NordDrive", "commande_id": "ND-000549", "sku": "SKU-10005", "quantite": 17},
+        {"client": "NordDrive", "commande_id": "ND-000549", "sku": "SKU-10004", "quantite": 40},
+        {"client": "NordDrive", "commande_id": "ND-000549", "sku": "SKU-10003", "quantite": 27},
+    ]
+
+    deduped, conflicts = deduplicate(records)
+
+    assert len(deduped) == 3
+    assert conflicts == 0
+
+
+def test_deduplicate_resolves_conflicting_duplicate_with_last_value():
+    """Un vrai doublon (même commande + même produit) avec quantités différentes
+    est résolu en conservant la dernière occurrence, et compté comme conflit."""
+    records = [
+        {"client": "NordDrive", "commande_id": "ND-001297", "sku": "SKU-10008", "quantite": 6},
+        {"client": "NordDrive", "commande_id": "ND-001297", "sku": "SKU-10008", "quantite": 3},
+    ]
+
+    deduped, conflicts = deduplicate(records)
+
+    assert len(deduped) == 1
+    assert deduped[0]["quantite"] == 3
+    assert conflicts == 1
+
+
+def test_deduplicate_collapses_pure_formatting_duplicate_without_conflict():
+    """Deux lignes identiques une fois normalisées ne comptent pas comme un conflit."""
+    records = [
+        {"client": "MedioTex", "commande_id": "MTX-000265", "sku": "SKU-30026", "quantite": 20},
+        {"client": "MedioTex", "commande_id": "MTX-000265", "sku": "SKU-30026", "quantite": 20},
+    ]
+
+    deduped, conflicts = deduplicate(records)
+
+    assert len(deduped) == 1
+    assert conflicts == 0
+
+
+def test_clean_and_aggregate_produces_unique_dataset_and_report():
+    """L'agrégation des trois clients produit un jeu unique et un rapport de nettoyage."""
+    norddrive_raw = [
+        {
+            "ref_commande": "ND-000001",
+            "date_cde": "19-07-2026",
+            "reference_piece": "SKU-10005",
+            "designation": "Bougie",
+            "qte": "17",
+            "poids_unitaire_g": "5900",
+            "entrepot": "OMG-LIL",
+        },
+        {
+            "ref_commande": "ND-000002",
+            "date_cde": "19-07-2026",
+            "reference_piece": "SKU-10004",
+            "designation": "Filtre",
+            "qte": "",  # corrompue
+            "poids_unitaire_g": "1820",
+            "entrepot": "OMG-LIL",
+        },
+    ]
+    freshmarket_raw = [
+        {
+            "id_commande_client": "FM-000821",
+            "date_reception": "06-04-2025",
+            "code_article": "SKU-20011",
+            "libelle_produit": "Yaourt",
+            "quantite_commandee": "28",
+            "chaine_froid_requise": "OUI",
+            "site_livraison": "OMG-MAR",
+        },
+    ]
+    mediotex_raw = []
+
+    result = clean_and_aggregate(norddrive_raw, freshmarket_raw, mediotex_raw)
+
+    assert len(result["records"]) == 2
+    assert result["rapport"]["lignes_lues"] == {
+        "norddrive": 2,
+        "freshmarket": 1,
+        "mediotex": 0,
+    }
+    assert result["rapport"]["lignes_corrompues_supprimees"] == 1
+    assert result["rapport"]["doublons_supprimes"] == 0
+    assert result["rapport"]["conflits_resolus"] == 0

--- a/tests/unit/test_clients_cleaning.py
+++ b/tests/unit/test_clients_cleaning.py
@@ -10,10 +10,10 @@ import pytest
 
 from datacore.processing.clients_cleaning import (
     clean_and_aggregate,
-    clean_freshmarket,
-    clean_mediotex,
-    clean_norddrive,
     deduplicate,
+    normalize_freshmarket,
+    normalize_mediotex,
+    normalize_norddrive,
     parse_date,
 )
 
@@ -37,7 +37,7 @@ def test_parse_date_rejects_unknown_format():
         parse_date("07.03.2025")
 
 
-def test_clean_norddrive_converts_grams_to_kg():
+def test_normalize_norddrive_converts_grams_to_kg():
     """Le poids NordDrive (grammes) est converti en kg, cohérent avec FluxPro."""
     raw = [
         {
@@ -51,14 +51,14 @@ def test_clean_norddrive_converts_grams_to_kg():
         }
     ]
 
-    cleaned = clean_norddrive(raw)
+    normalized = normalize_norddrive(raw)
 
-    assert cleaned[0]["poids_kg"] == 5.9
-    assert cleaned[0]["client"] == "NordDrive"
-    assert cleaned[0]["quantite"] == 17
+    assert normalized[0]["poids_kg"] == 5.9
+    assert normalized[0]["client"] == "NordDrive"
+    assert normalized[0]["quantite"] == 17
 
 
-def test_clean_norddrive_drops_rows_with_missing_quantite():
+def test_normalize_norddrive_drops_rows_with_missing_quantite():
     """Une ligne sans quantité est une entrée corrompue, écartée."""
     raw = [
         {
@@ -72,10 +72,10 @@ def test_clean_norddrive_drops_rows_with_missing_quantite():
         }
     ]
 
-    assert clean_norddrive(raw) == []
+    assert normalize_norddrive(raw) == []
 
 
-def test_clean_freshmarket_converts_oui_non_to_boolean():
+def test_normalize_freshmarket_converts_oui_non_to_boolean():
     """Le booléen métier OUI/NON est converti en bool Python."""
     raw = [
         {
@@ -89,13 +89,13 @@ def test_clean_freshmarket_converts_oui_non_to_boolean():
         }
     ]
 
-    cleaned = clean_freshmarket(raw)
+    normalized = normalize_freshmarket(raw)
 
-    assert cleaned[0]["chaine_froid_requise"] is True
-    assert cleaned[0]["poids_kg"] is None
+    assert normalized[0]["chaine_froid_requise"] is True
+    assert normalized[0]["poids_kg"] is None
 
 
-def test_clean_mediotex_maps_columns_to_unified_schema():
+def test_normalize_mediotex_maps_columns_to_unified_schema():
     """Les colonnes MedioTex sont correctement projetées sur le schéma unifié."""
     raw = [
         {
@@ -108,11 +108,11 @@ def test_clean_mediotex_maps_columns_to_unified_schema():
         }
     ]
 
-    cleaned = clean_mediotex(raw)
+    normalized = normalize_mediotex(raw)
 
-    assert cleaned[0]["client"] == "MedioTex"
-    assert cleaned[0]["sku"] == "SKU-30027"
-    assert cleaned[0]["date_commande"] == "2026-06-07"
+    assert normalized[0]["client"] == "MedioTex"
+    assert normalized[0]["sku"] == "SKU-30027"
+    assert normalized[0]["date_commande"] == "2026-06-07"
 
 
 def test_deduplicate_keeps_legitimate_multi_product_orders():


### PR DESCRIPTION
## Résumé
- `src/datacore/processing/clients_cleaning.py` : normalise et fusionne les 3 fichiers clients en un jeu de données unique
  - `normalize_norddrive`/`normalize_freshmarket`/`normalize_mediotex` (renommées depuis `clean_*` suite à relecture — ce sont d'abord des fonctions de *normalisation*, le nom "clean" était trompeur) : suppression des entrées corrompues (quantité manquante — 56 lignes au total), homogénéisation des dates (**3 formats réels** : `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY-MM-DD`), conversion des unités (grammes → kg) et du booléen métier
  - `deduplicate()` : dédoublonnage au grain **(commande, produit)**, résolution des conflits par "dernière valeur gagne" — **hypothèse métier et ses limites désormais documentées explicitement** dans le docstring (mise à jour de commande par le client, non prouvable à partir des seules données, à valider avec les référents clients)
- `run_cleaning.py` consomme la zone d'atterrissage de C8 et écrit `data/interim/clients_consolidated.json`
- **`notebooks/exploration_fichiers_clients.ipynb`** (nouveau) : rend reproductible et vérifiable l'analyse qui a produit les chiffres cités dans la doc — jusque-là seulement exécutée ponctuellement en terminal, sans trace versionnée. Exécuté et vérifié : mêmes résultats que l'analyse manuelle.
- Clarifie ce que désigne le SKU dans les fichiers clients (`reference_piece`/`code_article`/`sku`) : le même référentiel produit que `produits.sku` côté FluxPro

## ⚠️ Correction d'un chiffre erroné dans C2 (déjà mergée)
En creusant les vrais doublons pour concevoir C10, j'ai découvert qu'un identifiant de commande répété correspond très majoritairement à une **commande multi-produits légitime** (comme `lignes_commande` dans FluxPro), pas à un doublon. Le grain correct est (commande, produit) : **13 à 17 %** de vrais doublons, pas 55-68 % comme mesuré initialement (au grain commande seul) dans `topographie_donnees.md`. Corrigé partout où ce chiffre était cité : `topographie_donnees.md`, `architecture_cible.md`, `veille_technique_reglementaire.md`, `sequencement_bloc2.md`.

## Closes
Closes #28

## Test plan
- [x] `ruff check .` (couvre aussi le notebook) + `pytest` : 42/42 tests passent
- [x] Test de bout en bout sur les données réelles (Docker Compose + C8 + C10) : 4263 lignes lues → 56 corrompues supprimées → 614 doublons supprimés (536 conflits résolus) → 3593 lignes consolidées
- [x] Notebook exécuté de bout en bout (extraction des cellules de code + exécution) : résultats identiques à l'analyse manuelle
- [x] Échantillon de sortie vérifié manuellement (dates ISO, poids en kg, booléen correct, conflit FM-000821/SKU-20011 résolu en gardant la dernière valeur)