### PR TITLE
docs: outputs d'exécution du notebook d'exploration

### DIFF
--- a/notebooks/exploration_fichiers_clients.ipynb
+++ b/notebooks/exploration_fichiers_clients.ipynb
@@ -20,9 +20,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "norddrive : 1479 lignes\n",
+      "freshmarket : 1288 lignes\n",
+      "mediotex : 1496 lignes\n"
+     ]
+    }
+   ],
    "source": [
     "import csv\n",
     "from collections import Counter\n",
@@ -65,9 +75,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exemple : ND-000549 apparait 4 fois\n",
+      "  {'ref_commande': 'ND-000549', 'date_cde': '19-07-2026', 'reference_piece': 'SKU-10005', 'designation': \"Bougie d'allumage\", 'qte': '17', 'poids_unitaire_g': '5900', 'entrepot': 'OMG-LIL'}\n",
+      "  {'ref_commande': 'ND-000549', 'date_cde': '19-07-2026', 'reference_piece': 'SKU-10004', 'designation': 'Filtre a air', 'qte': '40', 'poids_unitaire_g': '1820', 'entrepot': 'OMG-LIL'}\n",
+      "  {'ref_commande': 'ND-000549', 'date_cde': '19-07-2026', 'reference_piece': 'SKU-10003', 'designation': 'Filtre a huile', 'qte': '27', 'poids_unitaire_g': '2240', 'entrepot': 'OMG-LIL'}\n",
+      "  {'ref_commande': 'ND-000549', 'date_cde': '2026-07-19', 'reference_piece': 'SKU-10003', 'designation': 'Filtre a huile', 'qte': '', 'poids_unitaire_g': '2240', 'entrepot': 'OMG-LIL'}\n"
+     ]
+    }
+   ],
    "source": [
     "name = \"norddrive\"\n",
     "path, sep, key, prod_key = FILES[name]\n",
@@ -95,9 +117,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "norddrive: 1479 lignes, 466 commandes uniques, 372 commandes avec plusieurs lignes (80% des commandes)\n",
+      "freshmarket: 1288 lignes, 441 commandes uniques, 354 commandes avec plusieurs lignes (80% des commandes)\n",
+      "mediotex: 1496 lignes, 493 commandes uniques, 388 commandes avec plusieurs lignes (79% des commandes)\n"
+     ]
+    }
+   ],
    "source": [
     "for name, (path, sep, key, prod_key) in FILES.items():\n",
     "    rows = rows_by_client[name]\n",
@@ -133,9 +165,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "norddrive: 1479 lignes, 1263 couples (commande, produit) uniques, 186 vrais doublons (14.7%)\n",
+      "freshmarket: 1288 lignes, 1110 couples (commande, produit) uniques, 161 vrais doublons (14.5%)\n",
+      "mediotex: 1496 lignes, 1260 couples (commande, produit) uniques, 218 vrais doublons (17.3%)\n"
+     ]
+    }
+   ],
    "source": [
     "for name, (path, sep, key, prod_key) in FILES.items():\n",
     "    rows = rows_by_client[name]\n",
@@ -158,9 +200,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Doublon ('ND-001297', 'SKU-10008') :\n",
+      "  {'ref_commande': 'ND-001297', 'date_cde': '2025-03-07', 'reference_piece': 'SKU-10008', 'designation': 'Batterie 12V', 'qte': '6', 'poids_unitaire_g': '740', 'entrepot': 'OMG-MAR'}\n",
+      "  {'ref_commande': 'ND-001297', 'date_cde': '07/03/2025', 'reference_piece': 'SKU-10008', 'designation': 'Batterie 12V', 'qte': '3', 'poids_unitaire_g': '740', 'entrepot': 'OMG-MAR'}\n",
+      "  {'ref_commande': 'ND-001297', 'date_cde': '07/03/2025', 'reference_piece': 'SKU-10008', 'designation': 'Batterie 12V', 'qte': '3', 'poids_unitaire_g': '740', 'entrepot': 'OMG-MAR'}\n"
+     ]
+    }
+   ],
    "source": [
     "name = \"norddrive\"\n",
     "path, sep, key, prod_key = FILES[name]\n",
@@ -199,9 +252,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- norddrive ---\n",
+      "  qte: 29 valeurs vides\n",
+      "--- freshmarket ---\n",
+      "  quantite_commandee: 27 valeurs vides\n",
+      "--- mediotex ---\n"
+     ]
+    }
+   ],
    "source": [
     "for name, (path, sep, key, prod_key) in FILES.items():\n",
     "    rows = rows_by_client[name]\n",
@@ -334,13 +399,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv (3.12.3)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Résumé
Récupère les outputs d'exécution du notebook `notebooks/exploration_fichiers_clients.ipynb`, exécuté dans l'IDE lors de la relecture de la PR #34. Les résultats confirment exactement les chiffres déjà cités dans `docs/architecture/topographie_donnees.md` et `src/datacore/processing/clients_cleaning.py`.

## Test plan
- [x] Outputs comparés aux résultats déjà vérifiés lors de l'exécution initiale du notebook — identiques