### PR TITLE
feat: requêtes SQL d'extraction documentées (C9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,21 @@ python3 -m datacore.processing.run_cleaning
 
 Écrit `data/interim/clients_consolidated.json` et affiche un rapport de
 nettoyage (lignes lues, entrées corrompues supprimées, doublons résolus).
+
+## Requêtes SQL d'extraction (C9)
+Charge l'historique volumineux dans la base de staging (table dédiée
+`historique_expeditions`) :
+
+```bash
+./scripts/load_historique.sh
+```
+
+Les requêtes documentées (commandes, stocks, expéditions FluxPro et
+historique) sont dans `sql/extraction/` — voir
+`docs/architecture/requetes_sql_extraction.md` pour le détail de chacune
+avec un échantillon de résultat. Exécution directe, par exemple :
+
+```bash
+docker compose -f infra/docker/docker-compose.yml exec -T db \
+  psql -U datacore -d datacore_staging < sql/extraction/01_commandes_par_client_periode.sql
+```

--- a/docs/architecture/requetes_sql_extraction.md
+++ b/docs/architecture/requetes_sql_extraction.md
@@ -1,0 +1,133 @@
+# Requêtes SQL d'extraction documentées — DATA CORE
+
+**Compétence couverte : C9 — Développer des requêtes SQL d'extraction**
+**Épreuve associée : E4 (mise en situation professionnelle)**
+
+Ce document décrit les requêtes SQL versionnées dans
+[`sql/extraction/`](../../sql/extraction/), qui extraient les commandes,
+stocks et expéditions depuis la base FluxPro importée (C8, `data/schema.sql`)
+et depuis l'historique volumineux chargé dans la base de staging (voir
+§1 ci-dessous). Chaque requête est exécutable telle quelle contre la
+base de staging PostgreSQL (`infra/docker/docker-compose.yml`).
+
+---
+
+## 1. Chargement de l'historique (« système big data »)
+
+Choix technique : l'historique (25 000 lignes, `data/raw/historique/
+omega_historique_expeditions.csv`) est chargé dans la **même base de
+staging PostgreSQL** déjà en place (issue #7), dans une table dédiée
+`historique_expeditions` (schéma :
+[`sql/historique_schema.sql`](../../sql/historique_schema.sql)), plutôt
+que dans un outil « big data » dédié (Spark, DuckDB...).
+
+**Justification** : ce volume reste largement dans les capacités d'un
+SGBD relationnel classique ; introduire un outil supplémentaire serait
+disproportionné et contraire au principe de sobriété retenu (RGESN, voir
+[architecture cible §5](architecture_cible.md#5-stratégie-déco-responsabilité-rgesn)).
+Réutiliser la base de staging permet en plus des requêtes croisées avec
+les données FluxPro.
+
+```bash
+./scripts/load_historique.sh
+```
+
+---
+
+## 2. Requêtes documentées
+
+### 2.1 Commandes par client et par période
+[`sql/extraction/01_commandes_par_client_periode.sql`](../../sql/extraction/01_commandes_par_client_periode.sql)
+
+Nombre de commandes et quantité totale par client et par mois (FluxPro :
+`commandes` + `clients` + `lignes_commande`). Brique pour le futur
+tableau de bord OMEGA BI (bloc 3, C13 — taux de service par
+client/période).
+
+```
+   client    |          mois          | nb_commandes | quantite_totale
+-------------+------------------------+--------------+-----------------
+ FreshMarket | 2025-01-01 00:00:00+00 |           20 |             927
+ FreshMarket | 2025-02-01 00:00:00+00 |           21 |            1190
+ FreshMarket | 2025-03-01 00:00:00+00 |           27 |            1562
+ ...
+```
+
+### 2.2 Stocks par entrepôt
+[`sql/extraction/02_stocks_par_entrepot.sql`](../../sql/extraction/02_stocks_par_entrepot.sql)
+
+Stocks actuels par entrepôt et produit, avec repère de rupture
+(`quantite = 0`). Répond directement à l'irritant remonté par les
+responsables d'entrepôt en entretien
+([étude de faisabilité §2.3](etude_faisabilite.md#23-entretien-avec-les-responsables-dentrepôt-lyon-lille-marseille)) :
+« les ruptures de stock ne sont détectées que lorsqu'une commande
+échoue ». Aucune rupture n'est observée sur l'instantané actuel des
+données (`SELECT count(*) FROM stocks WHERE quantite = 0` → 0), mais la
+requête est prête à en détecter dès qu'une surviendra.
+
+```
+         entrepot         |    sku    |         libelle          | quantite |  date_maj  | en_rupture
+--------------------------+-----------+--------------------------+----------+------------+------------
+ Entrepot Omega Lille     | SKU-10001 | Plaquette de frein       |       16 | 2026-08-01 | f
+ Entrepot Omega Lille     | SKU-10002 | Disque de frein          |      708 | 2026-07-28 | f
+ ...
+```
+
+### 2.3 Expéditions en retard
+[`sql/extraction/03_expeditions_en_retard.sql`](../../sql/extraction/03_expeditions_en_retard.sql)
+
+Expéditions livrées après leur date prévue, avec le nombre de jours de
+retard. Alimente directement l'indicateur « taux de service » attendu
+par la Direction des Opérations
+([étude de faisabilité §4](etude_faisabilite.md#4-étude-dopportunité)).
+
+```
+ tracking_number |     transporteur      |   client    | date_livraison_prevue | date_livraison_reelle | jours_retard
+------------------+-----------------------+-------------+------------------------+------------------------+--------------
+ OMG0001333      | EcoRoute              | NordDrive   | 2025-08-30            | 2025-09-02            |            3
+ OMG0000527      | RapidFret             | MedioTex    | 2025-07-30            | 2025-08-02            |            3
+ ...
+```
+
+### 2.4 Délais et coûts par client (historique)
+[`sql/extraction/04_historique_delais_couts_par_client.sql`](../../sql/extraction/04_historique_delais_couts_par_client.sql)
+
+Délai moyen de livraison, coût de transport moyen et taux de retard par
+client, sur l'historique volumineux (2022-2026).
+
+```
+   client    | nb_expeditions | delai_moyen_jours | cout_moyen_eur | taux_retard_pct
+-------------+----------------+-------------------+-----------------+-----------------
+ FreshMarket |           8297 |               2.2 |           48.26 |            11.2
+ NordDrive   |           8291 |               2.2 |           48.46 |            11.0
+ MedioTex    |           8412 |               2.2 |           48.43 |            10.6
+```
+
+### 2.5 Évolution annuelle du délai (historique)
+[`sql/extraction/05_evolution_delai_historique_par_annee.sql`](../../sql/extraction/05_evolution_delai_historique_par_annee.sql)
+
+Évolution annuelle du délai moyen de livraison par client — illustre une
+analyse de tendance sur la source « système big data », hors périmètre
+opérationnel FluxPro (qui ne couvre que les commandes en cours).
+
+```
+   client    | annee | nb_expeditions | delai_moyen_jours
+-------------+-------+----------------+-------------------
+ FreshMarket |  2022 |           1784 |               2.2
+ FreshMarket |  2023 |           1799 |               2.2
+ FreshMarket |  2024 |           1865 |               2.2
+ FreshMarket |  2025 |           1823 |               2.2
+ FreshMarket |  2026 |           1026 |               2.1
+ ...
+```
+
+---
+
+## 3. Point de vigilance pour C11/C13
+
+Les requêtes 2.1-2.3 utilisent `clients.nom` (FluxPro) ; les requêtes
+2.4-2.5 utilisent `historique_expeditions.client` (libellé texte libre).
+Un rapprochement explicite (`clients.nom` ↔ `historique_expeditions.client`)
+sera nécessaire lors de la modélisation de la base de travail consolidée
+(C11) et de l'entrepôt de données (bloc 3, C13) — déjà anticipé dans la
+[topographie des données §3.4](topographie_donnees.md#34-historique-volumineux--système-big-data-).

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -57,7 +57,7 @@ pour M1). Release mergée sur `main` via la PR #25.
 
 ### M1 — Collecte & Stockage (en cours)
 - [x] Extraction automatisée multi-source C8 (#26)
-- [ ] Requêtes SQL d'extraction documentées C9 (#27)
+- [x] Requêtes SQL d'extraction documentées C9 (#27)
 - [x] Agrégation et nettoyage des fichiers clients C10 (#28)
 - [ ] Base de données de travail — modélisation MERISE C11 (#29)
 - [ ] API Omega Data — exposition sécurisée C12 (#30)

--- a/scripts/load_historique.sh
+++ b/scripts/load_historique.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Cree la table historique_expeditions et importe le CSV volumineux
+# (25 000 lignes) dans la base de staging Postgres demarree via
+# infra/docker/docker-compose.yml (C9).
+#
+# Prerequis : `docker compose -f infra/docker/docker-compose.yml up -d`
+# et le pack technique present dans data/raw/ (voir README).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ ! -f .env ]; then
+  echo "Fichier .env introuvable : copiez .env.example en .env avant de lancer ce script." >&2
+  exit 1
+fi
+set -a
+source .env
+set +a
+
+HISTORIQUE_CSV="data/raw/historique/omega_historique_expeditions.csv"
+SCHEMA_FILE="sql/historique_schema.sql"
+
+if [ ! -f "$HISTORIQUE_CSV" ]; then
+  echo "Fichier manquant : $HISTORIQUE_CSV" >&2
+  echo "Copiez le contenu de datacore-dataset/data dans data/raw/ avant de lancer ce script." >&2
+  exit 1
+fi
+
+COMPOSE=(docker compose -f infra/docker/docker-compose.yml)
+PG_USER="${POSTGRES_USER:-datacore}"
+PG_DB="${POSTGRES_DB:-datacore_staging}"
+
+echo "Attente de la disponibilite de la base de staging..."
+until "${COMPOSE[@]}" exec -T db pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; do
+  sleep 1
+done
+
+echo "Creation de la table historique_expeditions..."
+"${COMPOSE[@]}" exec -T db psql -U "$PG_USER" -d "$PG_DB" < "$SCHEMA_FILE"
+
+echo "Import de l'historique depuis $HISTORIQUE_CSV..."
+"${COMPOSE[@]}" exec -T db psql -U "$PG_USER" -d "$PG_DB" \
+  -c "\\copy historique_expeditions FROM STDIN DELIMITER ',' CSV HEADER" < "$HISTORIQUE_CSV"
+
+echo "Import termine."

--- a/sql/extraction/01_commandes_par_client_periode.sql
+++ b/sql/extraction/01_commandes_par_client_periode.sql
@@ -1,0 +1,14 @@
+-- Objectif (C9) : nombre de commandes et quantité totale par client et
+-- par mois, sur la base FluxPro (commandes + lignes_commande).
+-- Sert de brique pour le futur tableau de bord OMEGA BI (bloc 3, C13 —
+-- taux de service par client/période).
+SELECT
+    c.nom AS client,
+    date_trunc('month', cmd.date_commande) AS mois,
+    count(DISTINCT cmd.id) AS nb_commandes,
+    sum(lc.quantite) AS quantite_totale
+FROM commandes cmd
+JOIN clients c ON c.id = cmd.client_id
+JOIN lignes_commande lc ON lc.commande_id = cmd.id
+GROUP BY c.nom, date_trunc('month', cmd.date_commande)
+ORDER BY client, mois;

--- a/sql/extraction/02_stocks_par_entrepot.sql
+++ b/sql/extraction/02_stocks_par_entrepot.sql
@@ -1,0 +1,16 @@
+-- Objectif (C9) : stocks actuels par entrepôt et produit, avec repère
+-- de rupture (quantité = 0) — répond à l'irritant remonté par les
+-- responsables d'entrepôt en entretien (voir docs/architecture/
+-- etude_faisabilite.md §2.3) : « les ruptures de stock ne sont
+-- détectées que lorsqu'une commande échoue ».
+SELECT
+    e.nom AS entrepot,
+    p.sku,
+    p.libelle,
+    s.quantite,
+    s.date_maj,
+    (s.quantite = 0) AS en_rupture
+FROM stocks s
+JOIN entrepots e ON e.id = s.entrepot_id
+JOIN produits p ON p.id = s.produit_id
+ORDER BY en_rupture DESC, entrepot, sku;

--- a/sql/extraction/03_expeditions_en_retard.sql
+++ b/sql/extraction/03_expeditions_en_retard.sql
@@ -1,0 +1,17 @@
+-- Objectif (C9) : expéditions livrées en retard (date réelle postérieure
+-- à la date prévue), avec le nombre de jours de retard — alimente
+-- directement l'indicateur « taux de service » attendu par la Direction
+-- des Opérations (voir docs/architecture/etude_faisabilite.md §4).
+SELECT
+    exp.tracking_number,
+    exp.transporteur,
+    c.nom AS client,
+    exp.date_livraison_prevue,
+    exp.date_livraison_reelle,
+    (exp.date_livraison_reelle - exp.date_livraison_prevue) AS jours_retard
+FROM expeditions exp
+JOIN commandes cmd ON cmd.id = exp.commande_id
+JOIN clients c ON c.id = cmd.client_id
+WHERE exp.date_livraison_reelle IS NOT NULL
+  AND exp.date_livraison_reelle > exp.date_livraison_prevue
+ORDER BY jours_retard DESC;

--- a/sql/extraction/04_historique_delais_couts_par_client.sql
+++ b/sql/extraction/04_historique_delais_couts_par_client.sql
@@ -1,0 +1,17 @@
+-- Objectif (C9) : délai moyen de livraison, coût de transport moyen et
+-- taux de retard par client, sur l'historique volumineux (25 000
+-- lignes, 2022-2026) chargé dans la base de staging (voir
+-- scripts/load_historique.sh). Illustre l'extraction depuis la source
+-- « système big data » attendue par le référentiel (C8/C9).
+SELECT
+    client,
+    count(*) AS nb_expeditions,
+    round(avg(delai_livraison_jours), 1) AS delai_moyen_jours,
+    round(avg(cout_transport_eur), 2) AS cout_moyen_eur,
+    round(
+        100.0 * sum(CASE WHEN statut = 'Retardee' THEN 1 ELSE 0 END) / count(*),
+        1
+    ) AS taux_retard_pct
+FROM historique_expeditions
+GROUP BY client
+ORDER BY taux_retard_pct DESC;

--- a/sql/extraction/05_evolution_delai_historique_par_annee.sql
+++ b/sql/extraction/05_evolution_delai_historique_par_annee.sql
@@ -1,0 +1,12 @@
+-- Objectif (C9) : évolution annuelle du délai moyen de livraison par
+-- client sur l'historique — illustre une analyse de tendance sur la
+-- source « système big data », hors périmètre opérationnel FluxPro
+-- (qui ne couvre que les commandes en cours).
+SELECT
+    client,
+    extract(YEAR FROM date_expedition) AS annee,
+    count(*) AS nb_expeditions,
+    round(avg(delai_livraison_jours), 1) AS delai_moyen_jours
+FROM historique_expeditions
+GROUP BY client, extract(YEAR FROM date_expedition)
+ORDER BY client, annee;

--- a/sql/historique_schema.sql
+++ b/sql/historique_schema.sql
@@ -1,0 +1,23 @@
+-- Schéma de la table historique_expeditions, alimentée depuis
+-- data/raw/historique/omega_historique_expeditions.csv (C9).
+--
+-- Choix technique : réutilisation de la base de staging PostgreSQL déjà
+-- en place (issue #7) plutôt qu'un outil « big data » dédié (Spark,
+-- DuckDB...) — le volume (25 000 lignes) reste largement dans les
+-- capacités d'un SGBD relationnel classique, et introduire un outil
+-- supplémentaire serait disproportionné et contraire au principe de
+-- sobriété retenu (RGESN, voir docs/architecture/architecture_cible.md
+-- §5). Cela permet aussi des requêtes croisées avec les données FluxPro
+-- (voir sql/extraction/).
+
+CREATE TABLE IF NOT EXISTS historique_expeditions (
+  id                      INTEGER PRIMARY KEY,
+  client                  VARCHAR(50)   NOT NULL,
+  entrepot                VARCHAR(50)   NOT NULL,
+  categorie_produit       VARCHAR(50),
+  date_expedition         DATE,
+  poids_kg                DECIMAL(8,2),
+  delai_livraison_jours   INTEGER,
+  cout_transport_eur      DECIMAL(8,2),
+  statut                  VARCHAR(30)
+);


### PR DESCRIPTION
## Résumé
- `sql/extraction/` : 5 requêtes SQL documentées et versionnées contre FluxPro et l'historique, chacune commentée sur son objectif métier et sa compétence
  1. Commandes par client/période (brique OMEGA BI, C13)
  2. Stocks par entrepôt avec repère de rupture (répond à l'irritant remonté par les responsables d'entrepôt en entretien, C1)
  3. Expéditions en retard (alimente le taux de service)
  4. Délais/coûts moyens par client sur l'historique
  5. Évolution annuelle du délai par client
- `scripts/load_historique.sh` + `sql/historique_schema.sql` : charge l'historique volumineux (25 000 lignes) dans la **même base de staging PostgreSQL** déjà en place (issue #7), justifié par la sobriété (RGESN) plutôt qu'un outil big data dédié disproportionné pour ce volume
- `docs/architecture/requetes_sql_extraction.md` : documente chaque requête avec un échantillon de résultat réel

## Closes
Closes #27

## Test plan
- [x] Testé de bout en bout (Docker Compose + `init_staging_db.sh` + `load_historique.sh`) : les 5 requêtes exécutées avec succès contre les vraies données
- [x] Résultats réels capturés et documentés (pas de données inventées)
- [x] Point de vigilance noté pour C11/C13 : rapprochement à faire entre `clients.nom` (FluxPro) et `historique_expeditions.client` (libellé texte libre)