### PR TITLE
docs: notebook de démonstration des requêtes SQL (C9)

### DIFF
--- a/docs/architecture/requetes_sql_extraction.md
+++ b/docs/architecture/requetes_sql_extraction.md
@@ -9,6 +9,8 @@ stocks et expéditions depuis la base FluxPro importée (C8, `data/schema.sql`)
 et depuis l'historique volumineux chargé dans la base de staging (voir
 §1 ci-dessous). Chaque requête est exécutable telle quelle contre la
 base de staging PostgreSQL (`infra/docker/docker-compose.yml`).
+Démonstration interactive avec sorties réelles :
+[`notebooks/requetes_sql_extraction.ipynb`](../../notebooks/requetes_sql_extraction.ipynb).
 
 ---
 

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -35,7 +35,8 @@ Voir architecture complète discutée avec Claude Web (conversation du 24/08/202
 
 `notebooks/` (ajouté le 26/08/2026) : explorations et analyses de
 données reproductibles, en appui des chiffres cités dans les livrables
-(ex. `notebooks/exploration_fichiers_clients.ipynb` pour C10).
+(ex. `notebooks/exploration_fichiers_clients.ipynb` pour C10,
+`notebooks/requetes_sql_extraction.ipynb` pour C9).
 
 ## État d'avancement
 

--- a/notebooks/requetes_sql_extraction.ipynb
+++ b/notebooks/requetes_sql_extraction.ipynb
@@ -1,0 +1,328 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Démonstration des requêtes SQL d'extraction (C9)\n",
+    "\n",
+    "Exécute les 5 requêtes documentées dans\n",
+    "[`sql/extraction/`](../sql/extraction/) contre la base de staging\n",
+    "PostgreSQL, pour en visualiser les sorties directement — complément\n",
+    "interactif à\n",
+    "[`docs/architecture/requetes_sql_extraction.md`](../docs/architecture/requetes_sql_extraction.md),\n",
+    "qui documente l'objectif métier de chaque requête.\n",
+    "\n",
+    "**Prérequis** : base de staging démarrée et peuplée\n",
+    "(`docker compose -f infra/docker/docker-compose.yml up -d`, puis\n",
+    "`./scripts/init_staging_db.sh` et `./scripts/load_historique.sh`).\n",
+    "\n",
+    "Toutes les jointures entre tables FluxPro (`commandes`, `clients`,\n",
+    "`lignes_commande`, `stocks`, `entrepots`, `produits`, `expeditions`)\n",
+    "sont des `INNER JOIN` (`JOIN` en SQL standard) : chaque ligne du\n",
+    "résultat exige une correspondance des deux côtés (ex. une commande sans\n",
+    "client rattaché, ou un stock sans produit rattaché, ne doit pas exister\n",
+    "dans une base FluxPro cohérente — un `INNER JOIN` reflète cette\n",
+    "contrainte, plutôt qu'un `LEFT JOIN` qui masquerait silencieusement une\n",
+    "incohérence de données).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connecte a la base de staging.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.insert(0, \"..\")  # pour importer datacore si le notebook est lance depuis notebooks/\n",
+    "\n",
+    "from datacore.ingestion.fluxpro import connect\n",
+    "\n",
+    "conn = connect()\n",
+    "conn.autocommit = True\n",
+    "print(\"Connecte a la base de staging.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_query(sql_path, limit=10):\n",
+    "    \"\"\"Execute un fichier .sql et affiche un apercu tabulaire du resultat.\n",
+    "\n",
+    "    Args:\n",
+    "        sql_path: chemin du fichier .sql a executer.\n",
+    "        limit: nombre maximum de lignes affichees (le compte total\n",
+    "            reste, lui, exact).\n",
+    "    \"\"\"\n",
+    "    with open(sql_path, encoding=\"utf-8\") as f:\n",
+    "        sql = f.read()\n",
+    "    cur = conn.cursor()\n",
+    "    cur.execute(sql)\n",
+    "    columns = [d[0] for d in cur.description]\n",
+    "    rows = cur.fetchall()\n",
+    "    shown = rows[:limit]\n",
+    "    widths = [\n",
+    "        max(len(str(c)), max((len(str(r[i])) for r in shown), default=0))\n",
+    "        for i, c in enumerate(columns)\n",
+    "    ]\n",
+    "    print(f\"{len(rows)} ligne(s) -- apercu des {len(shown)} premieres :\\n\")\n",
+    "    print(\" | \".join(c.ljust(w) for c, w in zip(columns, widths)))\n",
+    "    print(\"-+-\".join(\"-\" * w for w in widths))\n",
+    "    for r in shown:\n",
+    "        print(\" | \".join(str(v).ljust(w) for v, w in zip(r, widths)))\n",
+    "    return rows\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "source": [
+    "## 2.1 — Commandes par client et par période\n",
+    "\n",
+    "Nombre de commandes et quantité totale par client et par mois (FluxPro : `commandes` INNER JOIN `clients` INNER JOIN `lignes_commande`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "57 ligne(s) -- apercu des 10 premieres :\n",
+      "\n",
+      "client      | mois                      | nb_commandes | quantite_totale\n",
+      "------------+---------------------------+--------------+----------------\n",
+      "FreshMarket | 2025-01-01 00:00:00+00:00 | 20           | 927            \n",
+      "FreshMarket | 2025-02-01 00:00:00+00:00 | 21           | 1190           \n",
+      "FreshMarket | 2025-03-01 00:00:00+00:00 | 27           | 1562           \n",
+      "FreshMarket | 2025-04-01 00:00:00+00:00 | 22           | 1281           \n",
+      "FreshMarket | 2025-05-01 00:00:00+00:00 | 40           | 2717           \n",
+      "FreshMarket | 2025-06-01 00:00:00+00:00 | 19           | 936            \n",
+      "FreshMarket | 2025-07-01 00:00:00+00:00 | 22           | 1549           \n",
+      "FreshMarket | 2025-08-01 00:00:00+00:00 | 19           | 1230           \n",
+      "FreshMarket | 2025-09-01 00:00:00+00:00 | 20           | 1154           \n",
+      "FreshMarket | 2025-10-01 00:00:00+00:00 | 26           | 1764           \n"
+     ]
+    }
+   ],
+   "source": [
+    "run_query(\"../sql/extraction/01_commandes_par_client_periode.sql\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## 2.2 — Stocks par entrepôt\n",
+    "\n",
+    "Stocks actuels par entrepôt et produit, avec repère de rupture (`stocks` INNER JOIN `entrepots` INNER JOIN `produits`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "90 ligne(s) -- apercu des 10 premieres :\n",
+      "\n",
+      "entrepot             | sku       | libelle                  | quantite | date_maj   | en_rupture\n",
+      "---------------------+-----------+--------------------------+----------+------------+-----------\n",
+      "Entrepot Omega Lille | SKU-10001 | Plaquette de frein       | 16       | 2026-08-01 | False     \n",
+      "Entrepot Omega Lille | SKU-10002 | Disque de frein          | 708      | 2026-07-28 | False     \n",
+      "Entrepot Omega Lille | SKU-10003 | Filtre a huile           | 395      | 2026-07-29 | False     \n",
+      "Entrepot Omega Lille | SKU-10004 | Filtre a air             | 444      | 2026-07-29 | False     \n",
+      "Entrepot Omega Lille | SKU-10005 | Bougie d'allumage        | 117      | 2026-08-01 | False     \n",
+      "Entrepot Omega Lille | SKU-10006 | Amortisseur avant        | 30       | 2026-07-28 | False     \n",
+      "Entrepot Omega Lille | SKU-10007 | Courroie de distribution | 646      | 2026-07-28 | False     \n",
+      "Entrepot Omega Lille | SKU-10008 | Batterie 12V             | 687      | 2026-07-28 | False     \n",
+      "Entrepot Omega Lille | SKU-10009 | Retroviseur              | 692      | 2026-07-29 | False     \n",
+      "Entrepot Omega Lille | SKU-10010 | Pare-chocs avant         | 732      | 2026-07-29 | False     \n"
+     ]
+    }
+   ],
+   "source": [
+    "run_query(\"../sql/extraction/02_stocks_par_entrepot.sql\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "## 2.3 — Expéditions en retard\n",
+    "\n",
+    "Expéditions livrées après leur date prévue (`expeditions` INNER JOIN `commandes` INNER JOIN `clients`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "88 ligne(s) -- apercu des 10 premieres :\n",
+      "\n",
+      "tracking_number | transporteur          | client      | date_livraison_prevue | date_livraison_reelle | jours_retard\n",
+      "----------------+-----------------------+-------------+-----------------------+-----------------------+-------------\n",
+      "OMG0001333      | EcoRoute              | NordDrive   | 2025-08-30            | 2025-09-02            | 3           \n",
+      "OMG0000527      | RapidFret             | MedioTex    | 2025-07-30            | 2025-08-02            | 3           \n",
+      "OMG0000573      | TransUnion Logistique | FreshMarket | 2026-07-15            | 2026-07-18            | 3           \n",
+      "OMG0000588      | RapidFret             | MedioTex    | 2025-01-23            | 2025-01-26            | 3           \n",
+      "OMG0000600      | TransUnion Logistique | FreshMarket | 2026-04-07            | 2026-04-10            | 3           \n",
+      "OMG0000013      | EcoRoute              | MedioTex    | 2026-04-02            | 2026-04-05            | 3           \n",
+      "OMG0000131      | EcoRoute              | MedioTex    | 2026-04-25            | 2026-04-28            | 3           \n",
+      "OMG0000062      | TransUnion Logistique | FreshMarket | 2025-02-04            | 2025-02-07            | 3           \n",
+      "OMG0000320      | EcoRoute              | MedioTex    | 2026-03-03            | 2026-03-06            | 3           \n",
+      "OMG0001284      | RapidFret             | NordDrive   | 2025-07-05            | 2025-07-08            | 3           \n"
+     ]
+    }
+   ],
+   "source": [
+    "run_query(\"../sql/extraction/03_expeditions_en_retard.sql\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": [
+    "## 2.4 — Délais et coûts par client (historique)\n",
+    "\n",
+    "Délai moyen, coût moyen et taux de retard par client sur l'historique volumineux (`historique_expeditions`, sans jointure : source unique déjà consolidée).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 ligne(s) -- apercu des 3 premieres :\n",
+      "\n",
+      "client      | nb_expeditions | delai_moyen_jours | cout_moyen_eur | taux_retard_pct\n",
+      "------------+----------------+-------------------+----------------+----------------\n",
+      "FreshMarket | 8297           | 2.2               | 48.26          | 11.2           \n",
+      "NordDrive   | 8291           | 2.2               | 48.46          | 11.0           \n",
+      "MedioTex    | 8412           | 2.2               | 48.43          | 10.6           \n"
+     ]
+    }
+   ],
+   "source": [
+    "run_query(\"../sql/extraction/04_historique_delais_couts_par_client.sql\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "source": [
+    "## 2.5 — Évolution annuelle du délai (historique)\n",
+    "\n",
+    "Évolution annuelle du délai moyen de livraison par client.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15 ligne(s) -- apercu des 10 premieres :\n",
+      "\n",
+      "client      | annee | nb_expeditions | delai_moyen_jours\n",
+      "------------+-------+----------------+------------------\n",
+      "FreshMarket | 2022  | 1784           | 2.2              \n",
+      "FreshMarket | 2023  | 1799           | 2.2              \n",
+      "FreshMarket | 2024  | 1865           | 2.2              \n",
+      "FreshMarket | 2025  | 1823           | 2.2              \n",
+      "FreshMarket | 2026  | 1026           | 2.1              \n",
+      "MedioTex    | 2022  | 1801           | 2.2              \n",
+      "MedioTex    | 2023  | 1806           | 2.2              \n",
+      "MedioTex    | 2024  | 1831           | 2.2              \n",
+      "MedioTex    | 2025  | 1889           | 2.1              \n",
+      "MedioTex    | 2026  | 1085           | 2.2              \n"
+     ]
+    }
+   ],
+   "source": [
+    "run_query(\"../sql/extraction/05_evolution_delai_historique_par_annee.sql\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Les résultats obtenus ici confirment ceux déjà documentés dans\n",
+    "`docs/architecture/requetes_sql_extraction.md`. Le point de vigilance\n",
+    "noté pour C11/C13 reste valable : `clients.nom` (FluxPro) et\n",
+    "`historique_expeditions.client` (libellé texte libre) devront être\n",
+    "rapprochés explicitement lors de la modélisation de la base de travail\n",
+    "consolidée et de l'entrepôt de données.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé
- `notebooks/requetes_sql_extraction.ipynb` : exécute les 5 requêtes de `sql/extraction/` contre la base de staging (réutilise `datacore.ingestion.fluxpro.connect()`), affiche un aperçu tabulaire de chaque résultat — complément interactif à `docs/architecture/requetes_sql_extraction.md`
- Précise explicitement que les jointures FluxPro utilisées sont des `INNER JOIN` (cohérence référentielle attendue entre les tables), et pourquoi (pas de `LEFT JOIN` qui masquerait une incohérence de données)
- Référencé depuis la doc et le plan de développement

## Test plan
- [x] Exécuté de bout en bout (Docker Compose + `init_staging_db.sh` + `load_historique.sh`) : résultats identiques à ceux déjà documentés dans `requetes_sql_extraction.md`, outputs capturés dans le notebook
- [x] `ruff check .` (couvre le notebook) + `pytest` : 42/42 tests passent