### PR TITLE
ci: ajouter un job mypy (vérification de typage statique)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,19 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: ruff check .
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements-dev.txt
+      - run: mypy
+
   test:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, typecheck]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ pip install -r requirements-dev.txt   # installe aussi le package datacore en ed
 cd api-mock && python3 app.py   # API mock TransFlow sur :5050
 ```
 
+## Qualité de code (CI)
+Les mêmes vérifications que `.github/workflows/ci.yml` (lint, typage,
+tests), à lancer localement avant de pousser :
+
+```bash
+ruff check .
+mypy
+pytest tests/unit tests/integration -v
+```
+
 ## Setup via Docker Compose
 Alternative conteneurisée : base de staging PostgreSQL + API mock TransFlow.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,10 @@ select = ["E", "F", "I", "UP"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/integration"]
+
+[tool.mypy]
+python_version = "3.12"
+files = ["src/datacore"]
+warn_return_any = true
+warn_unused_ignores = true
+check_untyped_defs = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@
 -e .
 pytest>=8.0
 ruff>=0.6
+mypy>=1.11
+types-psycopg2>=2.9

--- a/src/datacore/ingestion/landing.py
+++ b/src/datacore/ingestion/landing.py
@@ -10,7 +10,7 @@ import datetime
 import decimal
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 def _json_default(value: Any) -> Any:
@@ -62,4 +62,6 @@ def read_records(path: Path) -> list[dict[str, Any]]:
         La liste de dictionnaires désérialisée.
     """
     with open(path, encoding="utf-8") as f:
-        return json.load(f)
+        # json.load() renvoie Any (contenu JSON non type) : cast explicite,
+        # l'appelant sait que write_records() y a ecrit une liste de dicts.
+        return cast(list[dict[str, Any]], json.load(f))

--- a/src/datacore/ingestion/portail_scraping.py
+++ b/src/datacore/ingestion/portail_scraping.py
@@ -26,7 +26,7 @@ def scrape_colis_list(base_url: str = TRANSFLOW_API_URL) -> list[str]:
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
     links = soup.select("a[href*='/portail-transporteur/colis/']")
-    return [a["href"].rsplit("/", 1)[-1] for a in links]
+    return [str(a["href"]).rsplit("/", 1)[-1] for a in links]
 
 
 def scrape_colis_detail(tracking_number: str, base_url: str = TRANSFLOW_API_URL) -> dict[str, Any]:
@@ -46,10 +46,14 @@ def scrape_colis_detail(tracking_number: str, base_url: str = TRANSFLOW_API_URL)
     resp = requests.get(f"{base_url}/portail-transporteur/colis/{tracking_number}", timeout=10)
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
-    rows = {
-        row.find("th").get_text(strip=True): row.find("td").get_text(strip=True)
-        for row in soup.select("table tr")
-    }
+    rows: dict[str, str] = {}
+    for row in soup.select("table tr"):
+        th, td = row.find("th"), row.find("td")
+        if th is None or td is None:
+            # Ligne de table sans en-tete ou sans valeur (HTML inattendu) :
+            # ignoree plutot que de lever une exception.
+            continue
+        rows[th.get_text(strip=True)] = td.get_text(strip=True)
     return {
         "tracking_number": tracking_number,
         "statut": rows.get("Statut"),

--- a/src/datacore/ingestion/transflow.py
+++ b/src/datacore/ingestion/transflow.py
@@ -5,7 +5,7 @@ Couvre la source « service web » attendue par le référentiel (voir
 ses réponses (`page`, `per_page`) : ce module boucle automatiquement sur
 toutes les pages pour renvoyer la collection complète.
 """
-from typing import Any
+from typing import Any, cast
 
 import requests
 
@@ -44,7 +44,10 @@ def fetch_transporteurs(base_url: str = TRANSFLOW_API_URL) -> list[dict[str, Any
     Returns:
         La liste des transporteurs.
     """
-    return _get_json("/api/transporteurs", None, base_url)
+    # _get_json() renvoie Any (reponse JSON generique, tantot liste tantot
+    # dict pagine selon la route) : cast explicite ici, ou l'appelant sait
+    # que /api/transporteurs renvoie une liste.
+    return cast(list[dict[str, Any]], _get_json("/api/transporteurs", None, base_url))
 
 
 def _fetch_paginated(path: str, params: dict[str, Any], base_url: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Résumé
- `.github/workflows/ci.yml` : nouveau job `typecheck` (mypy), parallèle à `lint`, requis avant `test`
- Config `[tool.mypy]` dans `pyproject.toml` (vérifie `src/datacore/`), avec `warn_return_any` + `check_untyped_defs`
- Corrige 4 erreurs révélées par mypy sur du code déjà mergé (C8) :
  - `portail_scraping.py` : `row.find("th")`/`find("td")` peuvent renvoyer `None` sur du HTML inattendu — gérait le cas par un crash implicite, ignore désormais proprement la ligne
  - `transflow.py`, `landing.py` : `cast()` explicite sur les retours `Any` de `json.load()`/`resp.json()`, pour documenter la frontière entre données externes non typées et le typage interne du reste du code
- Ajoute `mypy>=1.11` et `types-psycopg2` à `requirements-dev.txt`, et une section "Qualité de code (CI)" au README

## Note
Cette PR ne touche pas au code C11 (PR #38, toujours en relecture) — `src/datacore/storage/` n'existe pas encore sur `dev`, donc mypy n'y vérifie que 13 fichiers pour l'instant (ingestion, processing, api, config, governance). Une fois #38 mergée, `storage/` sera automatiquement couvert par ce même job sans changement.

## Test plan
- [x] `ruff check .` + `mypy` + `pytest` : tous verts localement