### PR TITLE
docs(c13): vérification empirique du rapprochement commandes_clients/commandes

### DIFF
--- a/docs/architecture/modelisation_merise.md
+++ b/docs/architecture/modelisation_merise.md
@@ -308,6 +308,17 @@ et ceux de ses clients, ce qui est hors du périmètre de ce programme.
 En revanche, le rapprochement `lignes_commande_clients.sku` ↔
 `produits.sku` est, lui, vérifié fiable à 100 % (§3.4).
 
+**Preuve empirique** (formalisée lors de la modélisation OMEGA BI, C13) :
+[`notebooks/verification_rapprochement_commandes.ipynb`](../../notebooks/verification_rapprochement_commandes.ipynb)
+quantifie pourquoi la jointure « trop fragile » évoquée ci-dessus l'est
+réellement — la clé candidate `(client, entrepot, date_commande)` est
+ambiguë sur 13,6 % des clés distinctes côté FluxPro (166/1223), et
+`omega_historique_expeditions.csv` ne porte de toute façon aucun
+identifiant de commande, SKU ni quantité permettant de servir de pont.
+Conséquence actée pour `Dim_Commande` (bloc 3) : commandes clients et
+commandes FluxPro y sont traitées comme deux faits distincts, non
+joignables au niveau ligne.
+
 ### 4.3 `HISTORIQUE_EXPEDITIONS.client` reste en texte libre
 
 Limite déjà documentée en C9

--- a/notebooks/verification_rapprochement_commandes.ipynb
+++ b/notebooks/verification_rapprochement_commandes.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a557e02c",
+   "metadata": {},
+   "source": [
+    "# Vérification empirique — rapprochement `commandes_clients` ↔ `commandes` (FluxPro)\n",
+    "\n",
+    "**Compétence couverte : C13 — Modéliser un entrepôt de données**\n",
+    "**Épreuve associée : E5**\n",
+    "\n",
+    "Ce notebook formalise, avec preuve chiffrée, une décision déjà actée sans\n",
+    "mesure formelle dans\n",
+    "[`modelisation_merise.md` §4.2](../docs/architecture/modelisation_merise.md#42-commandes_clients-reste-indépendante-de-commandes-fluxpro) :\n",
+    "`commandes_clients` (C10/C11, commandes brutes des clients) et `commandes`\n",
+    "(FluxPro, schéma fourni) ne peuvent pas être rapprochées de manière fiable\n",
+    "avec les données disponibles dans ce programme.\n",
+    "\n",
+    "Deux vérifications indépendantes :\n",
+    "1. La clé candidate `(client, entrepot, date_commande)` est ambiguë côté\n",
+    "   FluxPro — inutilisable comme clé de jointure.\n",
+    "2. `omega_historique_expeditions.csv` ne porte aucun identifiant capable de\n",
+    "   servir de pont entre les deux jeux de commandes (pas d'id de commande,\n",
+    "   pas de SKU, pas de quantité).\n",
+    "\n",
+    "**Conclusion anticipée** (vérifiée ci-dessous) : `Dim_Commande` (bloc 3)\n",
+    "devra traiter les commandes clients et les commandes FluxPro comme deux\n",
+    "faits distincts, non joignables au niveau ligne.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2cf3366",
+   "metadata": {},
+   "source": [
+    "## 1. Ambiguïté de la clé `(client, entrepot, date_commande)` côté FluxPro\n",
+    "\n",
+    "Si l'on tentait de rapprocher `commandes_clients` (une commande par\n",
+    "`(client, commande_id)`, sans lien connu vers `commandes.id`) et\n",
+    "`commandes` (FluxPro) via une clé composite plausible — client, entrepôt,\n",
+    "date — encore faudrait-il que cette clé identifie une commande FluxPro de\n",
+    "façon unique. Vérification sur les 1400 commandes FluxPro réelles.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b9dd7e86",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Commandes FluxPro chargées : 1400\n",
+      "Colonnes : ['id', 'client_id', 'entrepot_id', 'date_commande', 'statut']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import csv\n",
+    "from collections import Counter\n",
+    "from pathlib import Path\n",
+    "\n",
+    "RAW = Path(\"..\") / \"data\" / \"raw\"\n",
+    "\n",
+    "with open(RAW / \"clients.csv\") as f:\n",
+    "    clients_by_id = {r[\"id\"]: r[\"nom\"] for r in csv.DictReader(f)}\n",
+    "\n",
+    "with open(RAW / \"entrepots.csv\") as f:\n",
+    "    entrepots_by_id = {r[\"id\"]: r[\"ville\"] for r in csv.DictReader(f)}\n",
+    "\n",
+    "with open(RAW / \"commandes.csv\") as f:\n",
+    "    commandes = list(csv.DictReader(f))\n",
+    "\n",
+    "print(f\"Commandes FluxPro chargées : {len(commandes)}\")\n",
+    "print(\"Colonnes :\", list(commandes[0].keys()))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6de7d638",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Clés (client, entrepot, date_commande) distinctes : 1223\n",
+      "Clés partagées par plusieurs commandes le même jour : 166\n",
+      "Taux de clés ambiguës : 13.6 %\n",
+      "Commandes concernées par une clé ambiguë : 343 / 1400 (24.5 %)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Clé candidate en libellés lisibles (client, ville d'entrepôt, date),\n",
+    "# directement comparable au format texte libre utilisé par l'historique.\n",
+    "keys = [\n",
+    "    (clients_by_id[c[\"client_id\"]], entrepots_by_id[c[\"entrepot_id\"]], c[\"date_commande\"])\n",
+    "    for c in commandes\n",
+    "]\n",
+    "key_counts = Counter(keys)\n",
+    "\n",
+    "n_distinct = len(key_counts)\n",
+    "ambiguous = {k: n for k, n in key_counts.items() if n > 1}\n",
+    "n_ambiguous = len(ambiguous)\n",
+    "rows_in_ambiguous_keys = sum(ambiguous.values())\n",
+    "\n",
+    "print(f\"Clés (client, entrepot, date_commande) distinctes : {n_distinct}\")\n",
+    "print(f\"Clés partagées par plusieurs commandes le même jour : {n_ambiguous}\")\n",
+    "print(f\"Taux de clés ambiguës : {100 * n_ambiguous / n_distinct:.1f} %\")\n",
+    "print(f\"Commandes concernées par une clé ambiguë : {rows_in_ambiguous_keys} / {len(commandes)}\"\n",
+    "      f\" ({100 * rows_in_ambiguous_keys / len(commandes):.1f} %)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b06c9de6",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exemples de clés partagées par plusieurs commandes distinctes :\n",
+      "  (NordDrive, Marseille, 2025-12-23) -> 2 commandes FluxPro différentes\n",
+      "  (NordDrive, Lille, 2025-12-04) -> 2 commandes FluxPro différentes\n",
+      "  (MedioTex, Marseille, 2026-04-19) -> 2 commandes FluxPro différentes\n",
+      "  (NordDrive, Lyon, 2025-01-25) -> 2 commandes FluxPro différentes\n",
+      "  (MedioTex, Marseille, 2026-03-24) -> 2 commandes FluxPro différentes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemples concrets de clés ambiguës, pour illustrer le risque de jointure\n",
+    "print(\"Exemples de clés partagées par plusieurs commandes distinctes :\")\n",
+    "for k, n in list(ambiguous.items())[:5]:\n",
+    "    client, entrepot, date = k\n",
+    "    print(f\"  ({client}, {entrepot}, {date}) -> {n} commandes FluxPro différentes\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "076f4e65",
+   "metadata": {},
+   "source": [
+    "**Lecture** : 13,6 % des clés `(client, entrepot, date_commande)`\n",
+    "distinctes correspondent en réalité à *plusieurs* commandes FluxPro le même\n",
+    "jour (jusqu'à 24,5 % des commandes prises individuellement sont concernées\n",
+    "par une clé non unique). Une jointure sur cette clé rattacherait donc, dans\n",
+    "un cas sur huit environ, une commande cliente à la mauvaise commande\n",
+    "FluxPro (ou échouerait à choisir laquelle) — inutilisable comme clé\n",
+    "d'appariement fiable, ce qui confirme empiriquement la réserve déjà émise\n",
+    "dans `modelisation_merise.md` §4.2 (\"jointure arbitraire, trop fragile\").\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ec268b0",
+   "metadata": {},
+   "source": [
+    "## 2. `omega_historique_expeditions.csv` ne peut pas servir de pont\n",
+    "\n",
+    "Autre piste envisageable : utiliser l'historique des expéditions comme\n",
+    "table de passage entre `commandes_clients` et `commandes` (FluxPro),\n",
+    "puisqu'il porte lui aussi un champ `client`. Vérification de son schéma\n",
+    "réel.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c7116718",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Lignes de l'historique : 25000\n",
+      "Colonnes disponibles : ['id', 'client', 'entrepot', 'categorie_produit', 'date_expedition', 'poids_kg', 'delai_livraison_jours', 'cout_transport_eur', 'statut']\n",
+      "Champs nécessaires à un pont commande/ligne présents : aucun\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(RAW / \"historique\" / \"omega_historique_expeditions.csv\") as f:\n",
+    "    reader = csv.DictReader(f)\n",
+    "    columns = reader.fieldnames\n",
+    "    historique = list(reader)\n",
+    "\n",
+    "print(f\"Lignes de l'historique : {len(historique)}\")\n",
+    "print(\"Colonnes disponibles :\", columns)\n",
+    "\n",
+    "champs_necessaires_pour_pont = {\"commande_id\", \"sku\", \"quantite\"}\n",
+    "presents = champs_necessaires_pour_pont & set(columns)\n",
+    "print(f\"Champs nécessaires à un pont commande/ligne présents : {presents or 'aucun'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "293c1ec5",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exemple de ligne réelle :\n",
+      "{'id': '1', 'client': 'MedioTex', 'entrepot': 'Marseille', 'categorie_produit': 'Textile', 'date_expedition': '2024-04-11', 'poids_kg': '29.83', 'delai_livraison_jours': '1', 'cout_transport_eur': '52.37', 'statut': 'Retardee'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Exemple de ligne réelle :\")\n",
+    "print(historique[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d84cc91",
+   "metadata": {},
+   "source": [
+    "**Lecture** : l'historique ne porte ni identifiant de commande, ni SKU,\n",
+    "ni quantité — seulement `client` (texte libre), `entrepot` (texte libre,\n",
+    "ville), `categorie_produit` (catégorie, pas un produit précis),\n",
+    "`date_expedition` (date d'expédition, pas la date de commande), et des\n",
+    "mesures agrégées (`poids_kg`, `delai_livraison_jours`, `cout_transport_eur`,\n",
+    "`statut`). Structurellement, il ne peut relier une commande client à une\n",
+    "ligne de commande FluxPro : il n'y a rien à joindre au niveau ligne, et le\n",
+    "seul champ commun envisageable (`client`) souffre en plus de la même\n",
+    "limite de texte libre déjà documentée en C9/C11\n",
+    "(`modelisation_merise.md` §4.3).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd13561b",
+   "metadata": {},
+   "source": [
+    "## 3. Conclusion\n",
+    "\n",
+    "Les deux vérifications convergent : ni une clé composite `(client,\n",
+    "entrepot, date)` (ambiguë sur FluxPro), ni l'historique des expéditions\n",
+    "(dépourvu de tout identifiant de commande/ligne) ne permettent de\n",
+    "rapprocher fiablement `commandes_clients` et `commandes` (FluxPro) au\n",
+    "niveau ligne.\n",
+    "\n",
+    "**Décision confirmée pour C13** : `Dim_Commande` (et les faits associés,\n",
+    "`Fait_Commande` côté clients et `Fait_Expedition`/`Fait_Stock` côté\n",
+    "FluxPro) traiteront les commandes clients et les commandes FluxPro comme\n",
+    "**deux faits distincts**, sans tenter de rapprochement arbitraire au\n",
+    "niveau ligne — cohérent avec la modélisation déjà retenue en C11\n",
+    "(`modelisation_merise.md` §4.2), désormais appuyée par une preuve\n",
+    "chiffrée plutôt que par une seule affirmation.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Résumé

Formalise avec preuve chiffrée une décision déjà actée sans mesure
formelle dans `modelisation_merise.md` §4.2.

`notebooks/verification_rapprochement_commandes.ipynb` vérifie, sur les
données réelles :

1. La clé candidate `(client, entrepot, date_commande)` est ambiguë sur
   13,6 % des clés distinctes côté FluxPro (166/1223) — jusqu'à 24,5 %
   des commandes prises individuellement sont concernées.
2. `omega_historique_expeditions.csv` ne porte aucun identifiant de
   commande, SKU ni quantité — inutilisable comme pont.

**Conclusion actée pour C13** : `Dim_Commande` traitera les commandes
clients et les commandes FluxPro comme deux faits distincts, non
joignables au niveau ligne.

`modelisation_merise.md` §4.2 référence désormais ce notebook comme
preuve empirique.

Ceci n'est **pas** le livrable complet de l'issue #44 (modélisation
étoile/flocon) — seulement le point de vérification préalable, avant
d'enchaîner sur la conception effective de
`Fait_Expedition`/`Fait_Stock`/`Fait_Commande` et des dimensions.

## Vérifications

- `ruff check .` : OK
- `mypy` : OK
- `pytest tests/unit tests/integration -q` : 69 passed