### PR TITLE
feat: pipelines ETL vers l'entrepôt OMEGA BI (C15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,17 +134,20 @@ Ou via Docker Compose (service `omega-data-api`, inclus dans
 curl -H "X-API-Key: omega-data-engineer-2026" http://localhost:8000/commandes-clients
 ```
 
-## Entrepôt OMEGA BI (C13-C14)
+## Entrepôt OMEGA BI (C13-C15)
 Modélisation en étoile/flocon (bottom-up, 2 datamarts, dimensions
 conformées) — voir `docs/architecture/modelisation_omega_bi.md`. Créé
 dans une base Postgres distincte (`datacore_omega_bi`, même instance que
 la base de staging), 3 schémas Postgres (`dimensions`, `exploitation`,
 `commercial`), versionnée via un second environnement Alembic — voir
 `docs/architecture/creation_entrepot_omega_bi.md` pour la procédure
-complète :
+complète. Peuplé depuis la base de staging par un pipeline ETL
+(rechargement complet, quarantaine des lignes historique non
+rapprochées) — voir `docs/architecture/pipelines_etl_omega_bi.md` :
 
 ```bash
 ./scripts/init_omega_bi_db.sh
 alembic -c alembic_omega_bi.ini upgrade head
 python3 -m datacore.storage.warehouse.load_dim_temps
+python3 -m datacore.storage.warehouse.load_warehouse
 ```

--- a/docs/architecture/modelisation_omega_bi.md
+++ b/docs/architecture/modelisation_omega_bi.md
@@ -452,3 +452,5 @@ pas par principe).
   travail, référence pour les exclusions RGPD *by design* de §6.5.
 - [`creation_entrepot_omega_bi.md`](creation_entrepot_omega_bi.md) —
   création physique de l'entrepôt implémentant ce schéma (C14).
+- [`pipelines_etl_omega_bi.md`](pipelines_etl_omega_bi.md) — pipeline
+  ETL peuplant l'entrepôt depuis la base de staging (C15).

--- a/docs/architecture/pipelines_etl_omega_bi.md
+++ b/docs/architecture/pipelines_etl_omega_bi.md
@@ -1,0 +1,167 @@
+# Pipelines ETL vers l'entrepôt OMEGA BI
+
+**Compétence couverte : C15 — Développer des pipelines de données**
+**Épreuve associée : E5**
+
+Ce document décrit le pipeline ETL qui peuple l'entrepôt OMEGA BI
+(schéma créé en C14) depuis la base de travail (staging, C11), en
+appliquant les règles de transformation conçues en C13
+(`docs/architecture/modelisation_omega_bi.md`).
+
+---
+
+## 1. Architecture du pipeline
+
+[`src/datacore/storage/warehouse/load_warehouse.py`](../../src/datacore/storage/warehouse/load_warehouse.py) :
+une fonction par table de dimension/fait, orchestrées par `main()`.
+Deux bases Postgres distinctes (staging et entrepôt) : aucune jointure
+SQL croisée possible, toute transformation se fait en Python entre
+l'extraction (lecture staging) et le chargement (écriture entrepôt).
+
+```bash
+alembic -c alembic_omega_bi.ini upgrade head    # si pas déjà fait (C14)
+python3 -m datacore.storage.warehouse.load_dim_temps  # si pas déjà fait (C14)
+python3 -m datacore.storage.warehouse.load_warehouse
+```
+
+**Rechargement complet, pas incrémental** : chaque exécution vide
+d'abord les 8 tables qu'elle alimente (`TRUNCATE ... CASCADE`, tout sauf
+`dimensions.dim_temps` — chargée séparément par C14) puis recharge tout
+depuis staging. Choix délibéré : cohérent avec le rythme batch
+quotidien/hebdomadaire prévu (`architecture_cible.md`, flux F6) et avec
+l'absence d'historisation avant C17 (SCD2 sur `Dim_Client`) — un
+rechargement complet est plus simple à raisonner et à tester qu'une
+logique d'upsert incrémentale tant qu'aucune dimension ne conserve
+d'historique. **Idempotent par construction** (pas via `ON CONFLICT`) :
+rejouer le pipeline produit exactement le même état, vérifié pour de
+vrai en le lançant deux fois de suite (voir §4).
+
+---
+
+## 2. Règles de transformation
+
+| Table entrepôt | Source(s) staging | Règle |
+|---|---|---|
+| `dimensions.dim_client` | `clients` | Copie directe, clé de substitution générée |
+| `dimensions.dim_site` | `entrepots` | Copie directe |
+| `dimensions.dim_categorie` | `produits.categorie` (valeurs distinctes) | Dimension à grain réduit, conforme aux deux sources de `Fait_Expedition` |
+| `dimensions.dim_produit` | `produits` | Copie + FK vers `dim_categorie` |
+| `dimensions.dim_transporteur` | `transporteurs` | `nom` uniquement (`contact` exclu, RGPD *by design*) + membre « Inconnu » |
+| `exploitation.fait_stock` | `stocks` | Grain (entrepôt, produit, date) direct |
+| `commercial.fait_commande` | `commandes` + `lignes_commande` | Grain ligne ; `poids_ligne = quantite × produits.poids_kg` |
+| `exploitation.fait_expedition` | `expeditions` + `commandes` + `lignes_commande` + `produits` (FluxPro/TransFlow) **et** `historique_expeditions` (Historique) | Voir §2.1 et §2.2 |
+
+### 2.1 `Fait_Expedition`, partie FluxPro/TransFlow
+
+- `poids_kg` : `expeditions` ne porte pas de poids directement — calculé
+  en sommant `lignes_commande.quantite × produits.poids_kg` pour la
+  commande liée (sous-requête corrélée).
+- `categorie_key` : dérivée du client, pas du produit — `expeditions`
+  n'a pas de lien direct vers un produit précis. S'appuie sur le fait
+  (vérifié empiriquement en C13,
+  `notebooks/exploration_donnees_omega_bi.ipynb` §2) qu'un client n'a
+  des produits que dans une seule catégorie ; `client_categorie_keys()`
+  revérifie cette hypothèse à l'exécution et lève une erreur explicite
+  si elle s'avérait fausse sur un futur jeu de données, plutôt que de
+  choisir une catégorie arbitrairement.
+- `transporteur_key` : `expeditions.transporteur` est un texte libre
+  (`"RapidFret"`), rapproché de `dim_transporteur.nom` par jointure
+  textuelle exacte — mécanisme déjà documenté et vérifié en C13
+  (`modelisation_omega_bi.md` §5.1).
+- `livre_a_lheure` : `date_livraison_reelle <= date_livraison_prevue` —
+  **même définition** que `datacore.api.repository.taux_service_par_client`
+  (C12), pour rester cohérent avec le KPI déjà exposé par l'API.
+  `None` si l'expédition n'est pas encore livrée
+  (`date_livraison_reelle IS NULL`).
+- `cout_transport_eur` : toujours `NULL` — absent de FluxPro/TransFlow
+  (limite déjà documentée en C13).
+
+### 2.2 `Fait_Expedition`, partie Historique — contrôle qualité par quarantaine
+
+`client`, `entrepot` et `categorie_produit` sont du texte libre côté
+historique, sans contrainte garantissant leur cohérence avec les
+référentiels FluxPro (voir `modelisation_omega_bi.md` §5.1/§8). Plutôt
+que d'insérer une ligne avec une clé de dimension incorrecte, ou de
+rejeter le chargement entier au premier écart, chaque ligne est
+vérifiée individuellement : si `client`, `entrepot` **ou**
+`categorie_produit` ne correspond à aucune valeur connue, la ligne est
+**mise en quarantaine** (comptée, non insérée) et le chargement continue.
+Le nombre de lignes en quarantaine est reporté dans le résumé
+d'exécution — sur ce jeu de données, **0 ligne en quarantaine** (les 3
+clients/entrepôts/catégories de l'historique correspondent exactement
+aux référentiels connus, vérifié en C13).
+
+`livre_a_lheure` reste `NULL` pour ces lignes : l'historique ne fournit
+qu'un délai constaté (`delai_livraison_jours`), pas de date de livraison
+prévue à comparer — calculer un « à l'heure » à partir du seul champ
+`statut` (`Retardee`/`Incident`) confondrait deux notions différentes
+(un flag de retard textuel vs. une comparaison de dates) ; non fait
+plutôt que d'inventer une règle non vérifiée.
+
+---
+
+## 3. Contrôles qualité
+
+- **Unicité** : `dimensions.dim_categorie.libelle` et le grain de
+  `exploitation.fait_stock` (`site_key`, `produit_key`, `date_key`) sont
+  contraints en base (C14, `UNIQUE`) — une violation lève une erreur
+  Postgres explicite plutôt que d'insérer un doublon silencieux.
+- **Doublons entre exécutions** : évités par construction (`TRUNCATE` +
+  rechargement complet, §1), pas par une logique `ON CONFLICT` à
+  maintenir.
+- **Rapprochement textuel de l'historique** : quarantaine ligne par
+  ligne plutôt que rejet en bloc ou clé fausse (§2.2).
+- **Hypothèse « un client = une catégorie »** : revérifiée à chaque
+  exécution (`client_categorie_keys`), `ValueError` explicite si mise en
+  défaut plutôt qu'un choix arbitraire silencieux.
+- **Formats de sortie** : `date_key` toujours dérivée via `_date_key()`
+  (garantit le format `YYYYMMDD` entier attendu par `dimensions.dim_temps`) ;
+  types alignés sur le schéma SQLAlchemy de C14 (`models.py`).
+
+---
+
+## 4. Procédure de test
+
+**Tests unitaires** (`tests/unit/test_load_warehouse.py`, 12 tests) :
+connexions/curseurs factices, sur le même principe que
+`test_load_staging.py`/`test_api_repository.py` — construction des
+mappings de clés, calcul de `poids_ligne`, dérivation de
+`livre_a_lheure`/`delai_livraison_jours` (livré vs. en cours), logique
+de quarantaine, `ValueError` sur l'hypothèse client/catégorie mise en
+défaut.
+
+**Test de bout en bout réel** (Docker Compose), effectué lors de la
+création de ce livrable — chaîne complète C7→C8→C9→C10→C11 (staging)
+puis C14→C15 (entrepôt) :
+
+```
+dim_client: 3, dim_site: 3, dim_categorie: 3, dim_produit: 30, dim_transporteur: 3 + 1 (Inconnu)
+fait_stock: 90, fait_commande: 4186, fait_expedition: 1100 (FluxPro/TransFlow) + 25000 (Historique)
+lignes historique mises en quarantaine: 0
+```
+
+Vérifications supplémentaires effectuées :
+- **Idempotence** : pipeline relancé deux fois de suite, comptes
+  strictement identiques au second passage.
+- **Cohérence avec l'API C12** : le taux de service par client calculé
+  depuis `Fait_Expedition` (`livre_a_lheure`) donne exactement les mêmes
+  chiffres que `taux_service_par_client` (staging direct) — ex.
+  FreshMarket 245 expéditions, 90,6 %, identique aux deux calculs.
+- **Cohérence des agrégats** : somme de `quantite_commandee` et
+  `poids_ligne` sur `Fait_Commande` identique à la somme calculée
+  directement sur `lignes_commande`/`produits` en staging (86 140 unités,
+  290 548,75 kg).
+- **Jointures de dimension** : `Fait_Stock` rejoint correctement
+  `Dim_Site`/`Dim_Produit`/`Dim_Temps` (échantillon vérifié ligne à
+  ligne contre `stocks.csv`).
+
+---
+
+## 5. Références
+
+- [`modelisation_omega_bi.md`](modelisation_omega_bi.md) — modélisation
+  étoile/flocon implémentée ici (C13).
+- [`creation_entrepot_omega_bi.md`](creation_entrepot_omega_bi.md) —
+  création physique de l'entrepôt (C14), prérequis de ce pipeline.
+- [`api_omega_data.md`](api_omega_data.md) — définition de
+  `taux_service_par_client`, réutilisée pour `livre_a_lheure` (§2.1).

--- a/docs/plan_de_developpement.md
+++ b/docs/plan_de_developpement.md
@@ -77,7 +77,7 @@ pour M2). Release vers `main` via la PR #42.
 ### M2 — Entrepôt OMEGA BI (en cours)
 - [x] Modélisation OMEGA BI — schémas étoile/flocon C13 (#44)
 - [x] Création de l'entrepôt OMEGA BI C14 (#45)
-- [ ] Pipelines ETL vers l'entrepôt OMEGA BI C15 (#46)
+- [x] Pipelines ETL vers l'entrepôt OMEGA BI C15 (#46)
 - [ ] Gestion opérationnelle de l'entrepôt OMEGA BI C16 (#47)
 - [ ] Variation de dimension SCD type 2 sur Dim_Client C17 (#48)
 

--- a/src/datacore/storage/warehouse/load_warehouse.py
+++ b/src/datacore/storage/warehouse/load_warehouse.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Pipeline ETL : base de travail (staging) vers l'entrepôt OMEGA BI (C15).
+
+Implémente les règles de transformation « table-relations vers
+faits-dimensions » conçues en C13
+(`docs/architecture/modelisation_omega_bi.md`) sur le schéma physique
+créé en C14. Deux bases Postgres distinctes (`STAGING_DB_DSN` et
+`OMEGA_BI_DB_DSN`) : aucune jointure croisée possible côté SQL, toute
+transformation se fait en Python entre l'extraction (staging) et le
+chargement (entrepôt).
+
+**Rechargement complet, pas incrémental** : chaque exécution vide
+d'abord les tables qu'il alimente (`truncate_warehouse`, hors
+`dimensions.dim_temps` — dimension générée, chargée séparément par
+`load_dim_temps.py`, C14) puis recharge tout depuis staging. Cohérent
+avec le rythme batch quotidien/hebdomadaire prévu
+(`docs/architecture/architecture_cible.md`, flux F6) et avec l'absence
+d'historisation avant C17 (SCD2 sur `Dim_Client`) : un rechargement
+complet est plus simple à raisonner qu'une logique d'upsert incrémentale
+tant qu'aucune dimension ne conserve d'historique.
+
+**Contrôles qualité** :
+- Unicité : `dimensions.dim_categorie.libelle` et le grain de
+  `exploitation.fait_stock` sont contraints en base (C14) — une
+  violation lève une erreur Postgres explicite plutôt que d'insérer un
+  doublon silencieux.
+- Rapprochement textuel de l'historique (`client`, `entrepot`,
+  `categorie_produit`) : les lignes qui ne correspondent à aucune valeur
+  connue sont mises en quarantaine (comptées, non insérées) plutôt que
+  rejetées en bloc ou insérées avec une clé fausse — voir
+  `load_fait_expedition_historique`.
+- Hypothèse « un client = une catégorie de produits » (vérifiée
+  empiriquement en C13,
+  `notebooks/exploration_donnees_omega_bi.ipynb` §2) : `ValueError`
+  explicite si elle s'avérait fausse, plutôt qu'une catégorie choisie
+  arbitrairement.
+
+Lancement (après `alembic -c alembic_omega_bi.ini upgrade head` et
+`python3 -m datacore.storage.warehouse.load_dim_temps`) :
+    python3 -m datacore.storage.warehouse.load_warehouse
+"""
+import datetime
+from typing import Any
+
+import psycopg2
+import psycopg2.extras
+
+from datacore.config import OMEGA_BI_DB_DSN, STAGING_DB_DSN
+
+FAIT_EXPEDITION_COLUMNS = """
+    client_key, site_key, categorie_key, date_key, transporteur_key,
+    tracking_number, source_systeme, poids_kg, delai_livraison_jours,
+    cout_transport_eur, statut, livre_a_lheure
+"""
+FAIT_EXPEDITION_PLACEHOLDERS = """
+    %(client_key)s, %(site_key)s, %(categorie_key)s, %(date_key)s, %(transporteur_key)s,
+    %(tracking_number)s, %(source_systeme)s, %(poids_kg)s, %(delai_livraison_jours)s,
+    %(cout_transport_eur)s, %(statut)s, %(livre_a_lheure)s
+"""
+
+
+def _date_key(d: datetime.date) -> int:
+    """Convertit une date en clé YYYYMMDD, le grain de `dimensions.dim_temps`."""
+    return int(d.strftime("%Y%m%d"))
+
+
+def _fetch_dicts(conn: Any, sql: str) -> list[dict[str, Any]]:
+    """Exécute une requête en lecture et renvoie les lignes sous forme de dicts.
+
+    Args:
+        conn: connexion psycopg2 ouverte (base de staging, en lecture seule ici).
+        sql: requête SELECT à exécuter.
+
+    Returns:
+        Une liste de dicts colonne -> valeur, une par ligne renvoyée.
+    """
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql)
+        return [dict(row) for row in cur.fetchall()]
+
+
+def _lookup_by_column(conn: Any, table: str, key_column: str, value_column: str) -> dict[Any, int]:
+    """Relit une table de l'entrepôt déjà chargée pour construire un dict valeur -> clé.
+
+    Utilisé pour les rapprochements textuels de l'historique (`nom`,
+    `ville`) sans dupliquer la logique de dérivation déjà appliquée lors
+    du chargement de la dimension.
+
+    Args:
+        conn: connexion psycopg2 ouverte sur l'entrepôt.
+        table: nom qualifié de la table (ex. `"dimensions.dim_client"`).
+        key_column: colonne de clé de substitution à renvoyer.
+        value_column: colonne de valeur à utiliser comme clé du dict.
+
+    Returns:
+        Un dict `{valeur: clé}`.
+    """
+    with conn.cursor() as cur:
+        cur.execute(f"SELECT {value_column}, {key_column} FROM {table}")  # noqa: S608
+        return dict(cur.fetchall())
+
+
+def truncate_warehouse(warehouse_conn: Any) -> None:
+    """Vide les tables alimentées par ce pipeline avant un rechargement complet.
+
+    `dimensions.dim_temps` n'est volontairement pas tronquée (voir
+    docstring du module).
+
+    Args:
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+    """
+    with warehouse_conn.cursor() as cur:
+        cur.execute("""
+            TRUNCATE
+                dimensions.dim_client, dimensions.dim_site,
+                dimensions.dim_categorie, dimensions.dim_produit,
+                dimensions.dim_transporteur,
+                exploitation.fait_expedition, exploitation.fait_stock,
+                commercial.fait_commande
+            CASCADE
+        """)
+
+
+def load_dim_client(staging_conn: Any, warehouse_conn: Any) -> dict[int, int]:
+    """Charge `Dim_Client` depuis `staging.clients`.
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+
+    Returns:
+        Mapping `clients.id` (staging) -> `client_key` (entrepôt).
+    """
+    rows = _fetch_dicts(staging_conn, "SELECT id, code, nom, secteur FROM clients ORDER BY id")
+    mapping: dict[int, int] = {}
+    with warehouse_conn.cursor() as cur:
+        for r in rows:
+            cur.execute(
+                """
+                INSERT INTO dimensions.dim_client (client_id, code, nom, secteur)
+                VALUES (%(id)s, %(code)s, %(nom)s, %(secteur)s)
+                RETURNING client_key
+                """,
+                r,
+            )
+            mapping[r["id"]] = cur.fetchone()[0]
+    return mapping
+
+
+def load_dim_site(staging_conn: Any, warehouse_conn: Any) -> dict[int, int]:
+    """Charge `Dim_Site` depuis `staging.entrepots`.
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+
+    Returns:
+        Mapping `entrepots.id` (staging) -> `site_key` (entrepôt).
+    """
+    rows = _fetch_dicts(
+        staging_conn, "SELECT id, code, nom, ville, capacite_palettes FROM entrepots ORDER BY id"
+    )
+    mapping: dict[int, int] = {}
+    with warehouse_conn.cursor() as cur:
+        for r in rows:
+            cur.execute(
+                """
+                INSERT INTO dimensions.dim_site (entrepot_id, code, nom, ville, capacite_palettes)
+                VALUES (%(id)s, %(code)s, %(nom)s, %(ville)s, %(capacite_palettes)s)
+                RETURNING site_key
+                """,
+                r,
+            )
+            mapping[r["id"]] = cur.fetchone()[0]
+    return mapping
+
+
+def load_dim_categorie(staging_conn: Any, warehouse_conn: Any) -> dict[str, int]:
+    """Charge `Dim_Categorie` : les catégories distinctes de `staging.produits`.
+
+    Dimension à grain réduit, conformée entre les deux sources de
+    `Fait_Expedition` — voir `modelisation_omega_bi.md` §6.3.
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+
+    Returns:
+        Mapping `produits.categorie` (libellé) -> `categorie_key` (entrepôt).
+    """
+    rows = _fetch_dicts(
+        staging_conn, "SELECT DISTINCT categorie FROM produits ORDER BY categorie"
+    )
+    mapping: dict[str, int] = {}
+    with warehouse_conn.cursor() as cur:
+        for r in rows:
+            cur.execute(
+                "INSERT INTO dimensions.dim_categorie (libelle) VALUES (%(categorie)s) "
+                "RETURNING categorie_key",
+                r,
+            )
+            mapping[r["categorie"]] = cur.fetchone()[0]
+    return mapping
+
+
+def load_dim_produit(
+    staging_conn: Any, warehouse_conn: Any, categorie_keys: dict[str, int]
+) -> dict[int, int]:
+    """Charge `Dim_Produit` depuis `staging.produits`.
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+        categorie_keys: mapping libellé -> `categorie_key`, produit par `load_dim_categorie`.
+
+    Returns:
+        Mapping `produits.id` (staging) -> `produit_key` (entrepôt).
+    """
+    rows = _fetch_dicts(
+        staging_conn,
+        "SELECT id, sku, libelle, poids_kg, temperature_dirigee, categorie "
+        "FROM produits ORDER BY id",
+    )
+    mapping: dict[int, int] = {}
+    with warehouse_conn.cursor() as cur:
+        for r in rows:
+            cur.execute(
+                """
+                INSERT INTO dimensions.dim_produit
+                    (produit_id, sku, libelle, poids_kg, temperature_dirigee, categorie_key)
+                VALUES
+                    (%(id)s, %(sku)s, %(libelle)s, %(poids_kg)s,
+                     %(temperature_dirigee)s, %(categorie_key)s)
+                RETURNING produit_key
+                """,
+                {**r, "categorie_key": categorie_keys[r["categorie"]]},
+            )
+            mapping[r["id"]] = cur.fetchone()[0]
+    return mapping
+
+
+def load_dim_transporteur(staging_conn: Any, warehouse_conn: Any) -> tuple[dict[str, int], int]:
+    """Charge `Dim_Transporteur` depuis `staging.transporteurs`, plus le membre « Inconnu ».
+
+    `contact` (donnée personnelle, voir `registre_rgpd.md`) n'est pas
+    repris — RGPD *by design*, voir `modelisation_omega_bi.md` §6.5. Le
+    membre « Inconnu » (`transporteur_id` NULL) couvre les lignes
+    `Fait_Expedition` issues de l'historique, qui ne portent pas cette
+    information.
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+
+    Returns:
+        Un couple (mapping `transporteurs.nom` -> `transporteur_key`,
+        `transporteur_key` du membre « Inconnu »). Une clé par nom, pas
+        par id : `expeditions.transporteur` (FluxPro) est un texte
+        libre, voir `modelisation_omega_bi.md` §5.1.
+    """
+    rows = _fetch_dicts(staging_conn, "SELECT id, nom FROM transporteurs ORDER BY id")
+    mapping: dict[str, int] = {}
+    with warehouse_conn.cursor() as cur:
+        for r in rows:
+            cur.execute(
+                "INSERT INTO dimensions.dim_transporteur (transporteur_id, nom) "
+                "VALUES (%(id)s, %(nom)s) RETURNING transporteur_key",
+                r,
+            )
+            mapping[r["nom"]] = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO dimensions.dim_transporteur (transporteur_id, nom) "
+            "VALUES (NULL, 'Inconnu') RETURNING transporteur_key"
+        )
+        inconnu_key = cur.fetchone()[0]
+    return mapping, inconnu_key
+
+
+def client_categorie_keys(staging_conn: Any, categorie_keys: dict[str, int]) -> dict[int, int]:
+    """Associe chaque `client_id` à la `categorie_key` de ses produits.
+
+    Chaque client de ce jeu de données n'a des produits que dans une
+    seule catégorie (vérifié empiriquement en C13,
+    `notebooks/exploration_donnees_omega_bi.ipynb` §2) — utilisé pour
+    dériver `Fait_Expedition.categorie_key` côté FluxPro/TransFlow, qui
+    n'a pas de lien direct vers un produit précis (voir
+    `modelisation_omega_bi.md` §5.1).
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        categorie_keys: mapping libellé -> `categorie_key`.
+
+    Returns:
+        Mapping `clients.id` -> `categorie_key`.
+
+    Raises:
+        ValueError: si un client a des produits dans plusieurs
+            catégories — romprait l'hypothèse vérifiée en C13.
+    """
+    rows = _fetch_dicts(
+        staging_conn, "SELECT DISTINCT client_id, categorie FROM produits ORDER BY client_id"
+    )
+    mapping: dict[int, int] = {}
+    for r in rows:
+        key = categorie_keys[r["categorie"]]
+        if r["client_id"] in mapping and mapping[r["client_id"]] != key:
+            raise ValueError(
+                f"client_id {r['client_id']} a des produits dans plusieurs catégories "
+                "-- hypothèse vérifiée en C13 mise en défaut"
+            )
+        mapping[r["client_id"]] = key
+    return mapping
+
+
+def load_fait_stock(
+    staging_conn: Any, warehouse_conn: Any, site_keys: dict[int, int], produit_keys: dict[int, int]
+) -> int:
+    """Charge `Fait_Stock` depuis `staging.stocks` (grain entrepôt x produit x date).
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+        site_keys: mapping `entrepots.id` -> `site_key`.
+        produit_keys: mapping `produits.id` -> `produit_key`.
+
+    Returns:
+        Le nombre de lignes insérées.
+    """
+    rows = _fetch_dicts(
+        staging_conn, "SELECT entrepot_id, produit_id, quantite, date_maj FROM stocks"
+    )
+    records = [
+        {
+            "site_key": site_keys[r["entrepot_id"]],
+            "produit_key": produit_keys[r["produit_id"]],
+            "date_key": _date_key(r["date_maj"]),
+            "quantite_stock": r["quantite"],
+        }
+        for r in rows
+    ]
+    with warehouse_conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO exploitation.fait_stock (site_key, produit_key, date_key, quantite_stock)
+            VALUES (%(site_key)s, %(produit_key)s, %(date_key)s, %(quantite_stock)s)
+            """,
+            records,
+        )
+    return len(records)
+
+
+def load_fait_commande(
+    staging_conn: Any,
+    warehouse_conn: Any,
+    client_keys: dict[int, int],
+    site_keys: dict[int, int],
+    produit_keys: dict[int, int],
+) -> int:
+    """Charge `Fait_Commande` depuis `staging.commandes`/`lignes_commande` (FluxPro).
+
+    Grain ligne de commande. `commandes_clients` n'est volontairement
+    pas mobilisée ici — voir `modelisation_omega_bi.md` §6.1.
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+        client_keys: mapping `clients.id` -> `client_key`.
+        site_keys: mapping `entrepots.id` -> `site_key`.
+        produit_keys: mapping `produits.id` -> `produit_key`.
+
+    Returns:
+        Le nombre de lignes insérées.
+    """
+    rows = _fetch_dicts(
+        staging_conn,
+        """
+        SELECT c.id AS commande_id, c.client_id, c.entrepot_id, c.date_commande, c.statut,
+               lc.produit_id, lc.quantite, p.poids_kg
+        FROM commandes c
+        JOIN lignes_commande lc ON lc.commande_id = c.id
+        JOIN produits p ON p.id = lc.produit_id
+        ORDER BY c.id, lc.id
+        """,
+    )
+    records = [
+        {
+            "client_key": client_keys[r["client_id"]],
+            "site_key": site_keys[r["entrepot_id"]],
+            "produit_key": produit_keys[r["produit_id"]],
+            "date_key": _date_key(r["date_commande"]),
+            "commande_id": str(r["commande_id"]),
+            "quantite_commandee": r["quantite"],
+            "poids_ligne": r["quantite"] * r["poids_kg"] if r["poids_kg"] is not None else None,
+            "statut_commande": r["statut"],
+        }
+        for r in rows
+    ]
+    with warehouse_conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO commercial.fait_commande
+                (client_key, site_key, produit_key, date_key, commande_id,
+                 quantite_commandee, poids_ligne, statut_commande)
+            VALUES
+                (%(client_key)s, %(site_key)s, %(produit_key)s, %(date_key)s, %(commande_id)s,
+                 %(quantite_commandee)s, %(poids_ligne)s, %(statut_commande)s)
+            """,
+            records,
+        )
+    return len(records)
+
+
+def load_fait_expedition_fluxpro(
+    staging_conn: Any,
+    warehouse_conn: Any,
+    client_keys: dict[int, int],
+    site_keys: dict[int, int],
+    client_cat_keys: dict[int, int],
+    transporteur_nom_keys: dict[str, int],
+) -> int:
+    """Charge la partie FluxPro/TransFlow de `Fait_Expedition`.
+
+    `poids_kg` est calculé en sommant `lignes_commande.quantite *
+    produits.poids_kg` pour la commande liée (`expeditions` ne porte pas
+    de poids directement) ; `categorie_key` est dérivée du client via
+    `client_cat_keys` (un client = une catégorie, voir
+    `client_categorie_keys`) ; `cout_transport_eur` reste NULL (absent
+    de FluxPro/TransFlow, voir `modelisation_omega_bi.md` §5.1) ;
+    `livre_a_lheure` réutilise la même définition que
+    `datacore.api.repository.taux_service_par_client`
+    (`date_livraison_reelle <= date_livraison_prevue`).
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+        client_keys: mapping `clients.id` -> `client_key`.
+        site_keys: mapping `entrepots.id` -> `site_key`.
+        client_cat_keys: mapping `clients.id` -> `categorie_key`.
+        transporteur_nom_keys: mapping `transporteurs.nom` -> `transporteur_key`.
+
+    Returns:
+        Le nombre de lignes insérées.
+    """
+    rows = _fetch_dicts(
+        staging_conn,
+        """
+        SELECT e.tracking_number, e.transporteur, e.date_expedition,
+               e.date_livraison_prevue, e.date_livraison_reelle, e.statut,
+               c.client_id, c.entrepot_id,
+               (SELECT sum(lc.quantite * p.poids_kg)
+                FROM lignes_commande lc JOIN produits p ON p.id = lc.produit_id
+                WHERE lc.commande_id = c.id) AS poids_kg
+        FROM expeditions e
+        JOIN commandes c ON c.id = e.commande_id
+        ORDER BY e.id
+        """,
+    )
+    records = []
+    for r in rows:
+        livree = r["date_livraison_reelle"] is not None
+        records.append({
+            "client_key": client_keys[r["client_id"]],
+            "site_key": site_keys[r["entrepot_id"]],
+            "categorie_key": client_cat_keys[r["client_id"]],
+            "date_key": _date_key(r["date_expedition"]),
+            "transporteur_key": transporteur_nom_keys[r["transporteur"]],
+            "tracking_number": r["tracking_number"],
+            "source_systeme": "FluxPro_TransFlow",
+            "poids_kg": r["poids_kg"],
+            "delai_livraison_jours": (
+                (r["date_livraison_reelle"] - r["date_expedition"]).days if livree else None
+            ),
+            "cout_transport_eur": None,
+            "statut": r["statut"],
+            "livre_a_lheure": (
+                r["date_livraison_reelle"] <= r["date_livraison_prevue"] if livree else None
+            ),
+        })
+    with warehouse_conn.cursor() as cur:
+        cur.executemany(
+            f"""
+            INSERT INTO exploitation.fait_expedition ({FAIT_EXPEDITION_COLUMNS})
+            VALUES ({FAIT_EXPEDITION_PLACEHOLDERS})
+            """,
+            records,
+        )
+    return len(records)
+
+
+def load_fait_expedition_historique(
+    staging_conn: Any,
+    warehouse_conn: Any,
+    client_nom_keys: dict[str, int],
+    site_ville_keys: dict[str, int],
+    categorie_keys: dict[str, int],
+    transporteur_inconnu_key: int,
+) -> tuple[int, int]:
+    """Charge la partie historique de `Fait_Expedition`, avec quarantaine des lignes
+    non rapprochées.
+
+    `client`/`entrepot`/`categorie_produit` sont du texte libre, non
+    garanti par contrainte (voir `modelisation_omega_bi.md` §5.1/§8) :
+    toute ligne dont l'une de ces valeurs ne correspond à aucune valeur
+    connue est mise en quarantaine (comptée, non insérée) plutôt
+    qu'insérée avec une clé fausse. `livre_a_lheure` reste NULL : aucune
+    date de livraison prévue n'est disponible dans cette source pour la
+    calculer (seul `delai_livraison_jours`, un délai constaté sans seuil
+    de référence, y figure).
+
+    Args:
+        staging_conn: connexion psycopg2 ouverte sur la base de staging.
+        warehouse_conn: connexion psycopg2 ouverte sur l'entrepôt.
+        client_nom_keys: mapping `dim_client.nom` -> `client_key`.
+        site_ville_keys: mapping `dim_site.ville` -> `site_key`.
+        categorie_keys: mapping `dim_categorie.libelle` -> `categorie_key`.
+        transporteur_inconnu_key: `transporteur_key` du membre « Inconnu ».
+
+    Returns:
+        Un couple (nombre de lignes insérées, nombre de lignes mises en quarantaine).
+    """
+    rows = _fetch_dicts(
+        staging_conn,
+        """
+        SELECT client, entrepot, categorie_produit, date_expedition,
+               poids_kg, delai_livraison_jours, cout_transport_eur, statut
+        FROM historique_expeditions
+        """,
+    )
+    records = []
+    n_quarantaine = 0
+    for r in rows:
+        if (
+            r["client"] not in client_nom_keys
+            or r["entrepot"] not in site_ville_keys
+            or r["categorie_produit"] not in categorie_keys
+        ):
+            n_quarantaine += 1
+            continue
+        records.append({
+            "client_key": client_nom_keys[r["client"]],
+            "site_key": site_ville_keys[r["entrepot"]],
+            "categorie_key": categorie_keys[r["categorie_produit"]],
+            "date_key": _date_key(r["date_expedition"]),
+            "transporteur_key": transporteur_inconnu_key,
+            "tracking_number": None,
+            "source_systeme": "Historique",
+            "poids_kg": r["poids_kg"],
+            "delai_livraison_jours": r["delai_livraison_jours"],
+            "cout_transport_eur": r["cout_transport_eur"],
+            "statut": r["statut"],
+            "livre_a_lheure": None,
+        })
+    with warehouse_conn.cursor() as cur:
+        cur.executemany(
+            f"""
+            INSERT INTO exploitation.fait_expedition ({FAIT_EXPEDITION_COLUMNS})
+            VALUES ({FAIT_EXPEDITION_PLACEHOLDERS})
+            """,
+            records,
+        )
+    return len(records), n_quarantaine
+
+
+def main() -> None:
+    """Exécute le pipeline complet : vide l'entrepôt (hors `dim_temps`) puis recharge tout.
+
+    Transaction unique côté entrepôt : un échec à n'importe quelle étape
+    annule (`ROLLBACK`) l'ensemble du rechargement plutôt que de laisser
+    l'entrepôt partiellement peuplé.
+    """
+    staging_conn = psycopg2.connect(STAGING_DB_DSN)
+    warehouse_conn = psycopg2.connect(OMEGA_BI_DB_DSN)
+    try:
+        truncate_warehouse(warehouse_conn)
+
+        client_keys = load_dim_client(staging_conn, warehouse_conn)
+        site_keys = load_dim_site(staging_conn, warehouse_conn)
+        categorie_keys = load_dim_categorie(staging_conn, warehouse_conn)
+        produit_keys = load_dim_produit(staging_conn, warehouse_conn, categorie_keys)
+        transporteur_nom_keys, transporteur_inconnu_key = load_dim_transporteur(
+            staging_conn, warehouse_conn
+        )
+
+        client_nom_keys = _lookup_by_column(
+            warehouse_conn, "dimensions.dim_client", "client_key", "nom"
+        )
+        site_ville_keys = _lookup_by_column(
+            warehouse_conn, "dimensions.dim_site", "site_key", "ville"
+        )
+        client_cat_keys = client_categorie_keys(staging_conn, categorie_keys)
+
+        n_stock = load_fait_stock(staging_conn, warehouse_conn, site_keys, produit_keys)
+        n_commande = load_fait_commande(
+            staging_conn, warehouse_conn, client_keys, site_keys, produit_keys
+        )
+        n_exp_fluxpro = load_fait_expedition_fluxpro(
+            staging_conn, warehouse_conn, client_keys, site_keys, client_cat_keys,
+            transporteur_nom_keys,
+        )
+        n_exp_hist, n_quarantaine = load_fait_expedition_historique(
+            staging_conn, warehouse_conn, client_nom_keys, site_ville_keys, categorie_keys,
+            transporteur_inconnu_key,
+        )
+
+        warehouse_conn.commit()
+        print(
+            f"dim_client: {len(client_keys)}, dim_site: {len(site_keys)}, "
+            f"dim_categorie: {len(categorie_keys)}, dim_produit: {len(produit_keys)}, "
+            f"dim_transporteur: {len(transporteur_nom_keys)} + 1 (Inconnu)\n"
+            f"fait_stock: {n_stock}, fait_commande: {n_commande}, "
+            f"fait_expedition: {n_exp_fluxpro} (FluxPro/TransFlow) + {n_exp_hist} (Historique)\n"
+            f"lignes historique mises en quarantaine: {n_quarantaine}"
+        )
+    except Exception:
+        warehouse_conn.rollback()
+        raise
+    finally:
+        staging_conn.close()
+        warehouse_conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_load_warehouse.py
+++ b/tests/unit/test_load_warehouse.py
@@ -1,0 +1,320 @@
+"""Tests unitaires du pipeline ETL staging -> entrepôt OMEGA BI (C15).
+
+Connexions/curseurs factices (pas de dépendance à une vraie base), sur
+le même principe que `tests/unit/test_load_staging.py` et
+`tests/unit/test_api_repository.py`. La correction du SQL et des
+jointures est vérifiée par un test de bout en bout contre une vraie base
+(Docker Compose), documenté dans
+`docs/architecture/pipelines_etl_omega_bi.md`.
+"""
+import datetime
+
+import pytest
+
+from datacore.storage.warehouse.load_warehouse import (
+    _date_key,
+    client_categorie_keys,
+    load_dim_categorie,
+    load_dim_client,
+    load_fait_commande,
+    load_fait_expedition_fluxpro,
+    load_fait_expedition_historique,
+    load_fait_stock,
+    truncate_warehouse,
+)
+
+
+class FakeStagingCursor:
+    """Curseur factice côté staging : renvoie une liste de dicts fixée, quelle
+    que soit la requête."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, sql, params=None):
+        pass
+
+    def fetchall(self):
+        return self._rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeStagingConnection:
+    """Connexion factice côté staging, en lecture seule pour ce pipeline."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self, cursor_factory=None):
+        return FakeStagingCursor(self._rows)
+
+
+class FakeWarehouseCursor:
+    """Curseur factice côté entrepôt : simule RETURNING via un compteur, enregistre les appels."""
+
+    def __init__(self):
+        self.execute_calls = []
+        self.executemany_calls = []
+        self._next_key = 1
+
+    def execute(self, sql, params=None):
+        self.execute_calls.append((sql, params))
+
+    def executemany(self, sql, records):
+        self.executemany_calls.append((sql, list(records)))
+
+    def fetchone(self):
+        key = self._next_key
+        self._next_key += 1
+        return (key,)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeWarehouseConnection:
+    """Connexion factice côté entrepôt, un unique curseur factice réutilisé."""
+
+    def __init__(self):
+        self.cursor_obj = FakeWarehouseCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+def test_date_key_convertit_en_yyyymmdd():
+    """_date_key convertit une date en entier YYYYMMDD."""
+    assert _date_key(datetime.date(2026, 8, 28)) == 20260828
+
+
+def test_truncate_warehouse_inclut_toutes_les_tables_hors_dim_temps():
+    """truncate_warehouse vide les 8 tables alimentées par ce pipeline, jamais dim_temps."""
+    warehouse_conn = FakeWarehouseConnection()
+
+    truncate_warehouse(warehouse_conn)
+
+    sql, _ = warehouse_conn.cursor_obj.execute_calls[0]
+    for table in [
+        "dimensions.dim_client", "dimensions.dim_site", "dimensions.dim_categorie",
+        "dimensions.dim_produit", "dimensions.dim_transporteur",
+        "exploitation.fait_expedition", "exploitation.fait_stock", "commercial.fait_commande",
+    ]:
+        assert table in sql
+    assert "dim_temps" not in sql
+    assert "CASCADE" in sql
+
+
+def test_load_dim_client_construit_le_mapping_id_vers_key():
+    """load_dim_client insère chaque client et associe son id staging à sa client_key générée."""
+    staging_conn = FakeStagingConnection([
+        {"id": 1, "code": "NORDDRIVE", "nom": "NordDrive", "secteur": "Pieces automobiles"},
+        {"id": 2, "code": "FRESHMARKET", "nom": "FreshMarket", "secteur": "Grande distribution"},
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    mapping = load_dim_client(staging_conn, warehouse_conn)
+
+    assert mapping == {1: 1, 2: 2}
+    assert len(warehouse_conn.cursor_obj.execute_calls) == 2
+    sql, params = warehouse_conn.cursor_obj.execute_calls[0]
+    assert "INSERT INTO dimensions.dim_client" in sql
+    assert params["nom"] == "NordDrive"
+
+
+def test_load_dim_categorie_une_ligne_par_categorie_distincte():
+    """load_dim_categorie insère une ligne par catégorie et construit le mapping libellé -> clé."""
+    staging_conn = FakeStagingConnection([
+        {"categorie": "Alimentaire"}, {"categorie": "Pieces auto"}, {"categorie": "Textile"},
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    mapping = load_dim_categorie(staging_conn, warehouse_conn)
+
+    assert set(mapping.keys()) == {"Alimentaire", "Pieces auto", "Textile"}
+    assert len(warehouse_conn.cursor_obj.execute_calls) == 3
+
+
+def test_client_categorie_keys_associe_un_client_a_une_categorie():
+    """client_categorie_keys construit le mapping client_id -> categorie_key attendu."""
+    staging_conn = FakeStagingConnection([
+        {"client_id": 1, "categorie": "Pieces auto"},
+        {"client_id": 2, "categorie": "Alimentaire"},
+    ])
+    categorie_keys = {"Pieces auto": 10, "Alimentaire": 20}
+
+    mapping = client_categorie_keys(staging_conn, categorie_keys)
+
+    assert mapping == {1: 10, 2: 20}
+
+
+def test_client_categorie_keys_leve_une_erreur_si_client_multi_categories():
+    """Un client avec des produits dans 2 catégories casse l'hypothèse vérifiée en C13."""
+    staging_conn = FakeStagingConnection([
+        {"client_id": 1, "categorie": "Pieces auto"},
+        {"client_id": 1, "categorie": "Textile"},
+    ])
+    categorie_keys = {"Pieces auto": 10, "Textile": 30}
+
+    with pytest.raises(ValueError, match="plusieurs catégories"):
+        client_categorie_keys(staging_conn, categorie_keys)
+
+
+def test_load_fait_stock_resout_les_cles_de_dimension():
+    """load_fait_stock traduit entrepot_id/produit_id en site_key/produit_key et pose date_key."""
+    staging_conn = FakeStagingConnection([
+        {
+            "entrepot_id": 2, "produit_id": 5, "quantite": 280,
+            "date_maj": datetime.date(2026, 7, 29),
+        },
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    n = load_fait_stock(staging_conn, warehouse_conn, site_keys={2: 200}, produit_keys={5: 500})
+
+    assert n == 1
+    sql, records = warehouse_conn.cursor_obj.executemany_calls[0]
+    assert "INSERT INTO exploitation.fait_stock" in sql
+    assert records == [
+        {"site_key": 200, "produit_key": 500, "date_key": 20260729, "quantite_stock": 280}
+    ]
+
+
+def test_load_fait_commande_calcule_le_poids_ligne():
+    """load_fait_commande calcule poids_ligne = quantite x poids_kg et stringifie commande_id."""
+    staging_conn = FakeStagingConnection([
+        {
+            "commande_id": 42, "client_id": 1, "entrepot_id": 2,
+            "date_commande": datetime.date(2026, 7, 19), "statut": "Livree",
+            "produit_id": 5, "quantite": 10, "poids_kg": 2.5,
+        },
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    n = load_fait_commande(
+        staging_conn, warehouse_conn,
+        client_keys={1: 100}, site_keys={2: 200}, produit_keys={5: 500},
+    )
+
+    assert n == 1
+    sql, records = warehouse_conn.cursor_obj.executemany_calls[0]
+    assert "INSERT INTO commercial.fait_commande" in sql
+    (record,) = records
+    assert record["commande_id"] == "42"
+    assert record["quantite_commandee"] == 10
+    assert record["poids_ligne"] == 25.0
+    assert record["client_key"] == 100
+
+
+def test_load_fait_commande_poids_ligne_none_si_poids_produit_inconnu():
+    """Sans poids_kg produit renseigné, poids_ligne reste None plutôt qu'une erreur de calcul."""
+    staging_conn = FakeStagingConnection([
+        {
+            "commande_id": 1, "client_id": 1, "entrepot_id": 2,
+            "date_commande": datetime.date(2026, 1, 1), "statut": "Livree",
+            "produit_id": 5, "quantite": 10, "poids_kg": None,
+        },
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    load_fait_commande(
+        staging_conn, warehouse_conn,
+        client_keys={1: 100}, site_keys={2: 200}, produit_keys={5: 500},
+    )
+
+    _, records = warehouse_conn.cursor_obj.executemany_calls[0]
+    assert records[0]["poids_ligne"] is None
+
+
+def test_load_fait_expedition_fluxpro_livree_a_lheure():
+    """Une expédition livrée avant/à la date prévue est marquée livre_a_lheure=True."""
+    staging_conn = FakeStagingConnection([
+        {
+            "tracking_number": "OMG0000001", "transporteur": "RapidFret",
+            "date_expedition": datetime.date(2025, 12, 24),
+            "date_livraison_prevue": datetime.date(2025, 12, 29),
+            "date_livraison_reelle": datetime.date(2025, 12, 29),
+            "statut": "Livree", "client_id": 1, "entrepot_id": 2, "poids_kg": 50.0,
+        },
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    n = load_fait_expedition_fluxpro(
+        staging_conn, warehouse_conn,
+        client_keys={1: 100}, site_keys={2: 200}, client_cat_keys={1: 300},
+        transporteur_nom_keys={"RapidFret": 400},
+    )
+
+    assert n == 1
+    _, records = warehouse_conn.cursor_obj.executemany_calls[0]
+    (record,) = records
+    assert record["livre_a_lheure"] is True
+    assert record["delai_livraison_jours"] == 5
+    assert record["source_systeme"] == "FluxPro_TransFlow"
+    assert record["cout_transport_eur"] is None
+    assert record["transporteur_key"] == 400
+
+
+def test_load_fait_expedition_fluxpro_en_cours_champs_derives_none():
+    """Une expédition non livrée (date_livraison_reelle NULL) laisse les champs dérivés à None."""
+    staging_conn = FakeStagingConnection([
+        {
+            "tracking_number": "OMG0000002", "transporteur": "EcoRoute",
+            "date_expedition": datetime.date(2026, 8, 1),
+            "date_livraison_prevue": datetime.date(2026, 8, 6),
+            "date_livraison_reelle": None,
+            "statut": "Expediee", "client_id": 1, "entrepot_id": 2, "poids_kg": 12.0,
+        },
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    load_fait_expedition_fluxpro(
+        staging_conn, warehouse_conn,
+        client_keys={1: 100}, site_keys={2: 200}, client_cat_keys={1: 300},
+        transporteur_nom_keys={"EcoRoute": 401},
+    )
+
+    _, records = warehouse_conn.cursor_obj.executemany_calls[0]
+    (record,) = records
+    assert record["livre_a_lheure"] is None
+    assert record["delai_livraison_jours"] is None
+
+
+def test_load_fait_expedition_historique_met_en_quarantaine_les_lignes_non_rapprochees():
+    """Une ligne avec un client/entrepot/categorie inconnu est comptée en
+    quarantaine, pas insérée."""
+    staging_conn = FakeStagingConnection([
+        {
+            "client": "NordDrive", "entrepot": "Lyon", "categorie_produit": "Pieces auto",
+            "date_expedition": datetime.date(2026, 1, 1), "poids_kg": 10.0,
+            "delai_livraison_jours": 2, "cout_transport_eur": 15.0, "statut": "Livree",
+        },
+        {
+            "client": "ClientInconnu", "entrepot": "Lyon", "categorie_produit": "Pieces auto",
+            "date_expedition": datetime.date(2026, 1, 2), "poids_kg": 5.0,
+            "delai_livraison_jours": 1, "cout_transport_eur": 8.0, "statut": "Livree",
+        },
+    ])
+    warehouse_conn = FakeWarehouseConnection()
+
+    n_inserees, n_quarantaine = load_fait_expedition_historique(
+        staging_conn, warehouse_conn,
+        client_nom_keys={"NordDrive": 100}, site_ville_keys={"Lyon": 200},
+        categorie_keys={"Pieces auto": 300}, transporteur_inconnu_key=999,
+    )
+
+    assert n_inserees == 1
+    assert n_quarantaine == 1
+    _, records = warehouse_conn.cursor_obj.executemany_calls[0]
+    assert len(records) == 1
+    assert records[0]["source_systeme"] == "Historique"
+    assert records[0]["transporteur_key"] == 999
+    assert records[0]["livre_a_lheure"] is None
+    assert records[0]["tracking_number"] is None


### PR DESCRIPTION
Closes #46

## Résumé

`src/datacore/storage/warehouse/load_warehouse.py` : peuple l'entrepôt
OMEGA BI (schéma C14) depuis la base de staging (C11), en appliquant les
règles de transformation conçues en C13. Deux bases Postgres distinctes
— toute transformation se fait en Python entre extraction et
chargement.

**Rechargement complet, pas incrémental** : chaque exécution vide
d'abord les 8 tables qu'elle alimente (`TRUNCATE ... CASCADE`, jamais
`dim_temps`, chargée séparément par C14) puis recharge tout — idempotent
par construction, cohérent avec l'absence d'historisation avant C17.

**Règles de transformation notables** :
- `Fait_Commande.poids_ligne = quantite × produits.poids_kg`.
- `Fait_Expedition` (FluxPro/TransFlow) : `poids_kg` sommé via
  `lignes_commande`/`produits` ; `categorie_key` dérivée du client
  (revérifiée à l'exécution, `ValueError` explicite si l'hypothèse
  « un client = une catégorie » venait à être fausse) ;
  `livre_a_lheure` réutilise **exactement** la définition déjà utilisée
  par `taux_service_par_client` (C12), pour rester cohérent avec le KPI
  déjà exposé par l'API.
- `Fait_Expedition` (Historique) : lignes dont `client`/`entrepot`/
  `categorie_produit` ne correspondent à aucune valeur connue **mises
  en quarantaine** (comptées, non insérées) plutôt qu'insérées avec une
  clé fausse ou rejetées en bloc.

Documentation complète : `docs/architecture/pipelines_etl_omega_bi.md`.

## Vérifié pour de vrai (Docker Compose, chaîne complète C7→C15)

```
dim_client: 3, dim_site: 3, dim_categorie: 3, dim_produit: 30, dim_transporteur: 3 + 1 (Inconnu)
fait_stock: 90, fait_commande: 4186, fait_expedition: 1100 (FluxPro/TransFlow) + 25000 (Historique)
lignes historique mises en quarantaine: 0
```

- **Idempotence** : pipeline relancé deux fois, comptes identiques.
- **Cohérence avec l'API C12** : taux de service par client calculé
  depuis `Fait_Expedition` identique au calcul direct sur staging
  (ex. FreshMarket 245 expéditions, 90,6 % dans les deux cas).
- **Cohérence des agrégats** : `Fait_Commande` (86 140 unités,
  290 548,75 kg) identique à l'agrégat direct staging.

## Vérifications

- `ruff check .` : OK
- `mypy` : OK
- `pytest tests/unit tests/integration -q` : 88 passed (+12 nouveaux tests)